### PR TITLE
Force deploy changed theme files

### DIFF
--- a/.github/workflows/deploy-theme.yml
+++ b/.github/workflows/deploy-theme.yml
@@ -41,6 +41,7 @@ jobs:
           FTP_USER: ${{ secrets.FTP_USER }}
           FTP_PASS: ${{ secrets.FTP_PASS }}
           FTP_PROTOCOL: ftps
+          FTP_SKIP_SAME_SIZE: "0"
           LOCAL_THEME_DIR: theme/svicloudtvbox-lumen
           REMOTE_THEME_DIR: public_html/wp-content/themes/svicloudtvbox-lumen
         run: |
@@ -56,6 +57,7 @@ jobs:
           FTP_USER: ${{ secrets.FTP_USER }}
           FTP_PASS: ${{ secrets.FTP_PASS }}
           FTP_PROTOCOL: ftps
+          FTP_SKIP_SAME_SIZE: "0"
           LOCAL_AGENT_ROOT: agent-root
           REMOTE_AGENT_ROOT: public_html
         run: |

--- a/scripts/validate_agent_resources.py
+++ b/scripts/validate_agent_resources.py
@@ -131,6 +131,8 @@ def main() -> None:
     workflow = WORKFLOW.read_text(encoding="utf-8")
     if "agent-root/**" not in workflow or "--no-delete-remote" not in workflow or "Deploy root agent files" not in workflow:
         fail("deploy workflow does not safely publish root llms files")
+    if 'FTP_SKIP_SAME_SIZE: "0"' not in workflow:
+        fail("deploy workflow can skip changed PHP files with matching byte sizes")
 
     print("OK: agent resources, answer hubs, schema, phone guards")
 


### PR DESCRIPTION
## Summary
- disable same-size FTP skips during theme/root-agent deploys
- add a static guard so deploy cannot silently skip changed PHP files with matching byte sizes

## Validation
- python3 -m py_compile scripts/validate_agent_resources.py scripts/validate_live_agent_friendly.py
- python3 scripts/validate_agent_resources.py
- git diff --check