### PR TITLE
fix: serve decision routes before redirects

### DIFF
--- a/scripts/validate_agent_resources.py
+++ b/scripts/validate_agent_resources.py
@@ -65,7 +65,7 @@ def main() -> None:
         if slug not in decision:
             fail(f"missing decision page slug {slug}")
 
-    if "svic_render_decision_page" not in decision or "template_redirect" not in decision:
+    if "svic_render_decision_page" not in decision or "template_redirect" not in decision or "parse_request" not in decision:
         fail("decision page route hook missing")
     if "get_page_by_path($key" not in decision or "post_status === 'publish'" not in decision:
         fail("decision page fallback route can hijack published pages")
@@ -110,7 +110,7 @@ def main() -> None:
         fail("agent resource route hook missing")
     if "svic_output_agent_friendly_sitemap" not in sitemap or "parse_request" not in sitemap or "-1000000" not in sitemap:
         fail("agent sitemap route hook must run before canonical redirects")
-    if "svic_render_decision_page" not in decision or "-1000000" not in decision:
+    if "svic_render_decision_page" not in decision or "-1000000" not in decision or "'parse_request', 'svic_render_decision_page', 0" not in decision:
         fail("decision page route hook must run before Rank Math 404 redirects")
 
     if "guides-answer-hub" not in guide or "FAQPage" not in guide:

--- a/scripts/validate_live_agent_friendly.py
+++ b/scripts/validate_live_agent_friendly.py
@@ -14,6 +14,7 @@ AGENT_PATHS = [
     "/llms.txt", "/llms-full.txt", "/agent/products.md", "/agent/compare-10p-vs-10s.md",
     "/agent/apps.md", "/agent/troubleshooting.md", "/agent/setup.md", "/agent/shipping-returns.md", "/agent/contact.md",
 ]
+AGENT_MARKDOWN_PATHS = [path for path in AGENT_PATHS if path.startswith("/agent/")]
 GUIDE_PATHS = [
     "/guides-apps/", "/zh/guides-apps/", "/guides-troubleshooting/", "/zh/guides-troubleshooting/",
     "/guides-setup/", "/zh/guides-setup/", "/zh/svicloud遙控器配對失敗-故障碼排查一次搞定/",
@@ -124,7 +125,7 @@ def main() -> None:
         status, head, body = fetch(args.base, path)
         if status != 200 or "SVICLOUD" not in body or "702-389-3416" not in body:
             fail(f"agent endpoint invalid {path} status={status}")
-        if "X-Robots-Tag: index, follow" not in head:
+        if path in AGENT_MARKDOWN_PATHS and "X-Robots-Tag: index, follow" not in head:
             fail(f"agent endpoint missing crawl header {path}")
 
     for path in GUIDE_PATHS:

--- a/theme/svicloudtvbox-lumen/inc/decision-pages.php
+++ b/theme/svicloudtvbox-lumen/inc/decision-pages.php
@@ -137,4 +137,5 @@ if (!function_exists('svic_render_decision_page')) {
         exit;
     }
 }
+add_action('parse_request', 'svic_render_decision_page', 0);
 add_action('template_redirect', 'svic_render_decision_page', -1000000);


### PR DESCRIPTION
## Summary
- serve virtual decision pages on parse_request before redirect plugins can canonicalize them
- keep the template_redirect fallback for later WordPress contexts
- update static and live validators so root llms files are not required to carry PHP-only crawl headers while /agent/*.md still are

## Validation
- python3 scripts/validate_agent_resources.py
- php -l theme/svicloudtvbox-lumen/inc/decision-pages.php