### PR TITLE
fix: purge agent route cache

### DIFF
--- a/.github/actions/purge-caches/action.yml
+++ b/.github/actions/purge-caches/action.yml
@@ -71,7 +71,7 @@ runs:
         # Falls back to purge_everything when site_url is absent.
         if [[ -n "${SITE_URL}" ]]; then
           SITE="${SITE_URL%/}"
-          PAYLOAD=$(python3 -c "import json; s='${SITE}'; urls=[s+'/',s+'/zh/',s+'/zh-cn/',s+'/shop/',s+'/zh/shop/',s+'/zh-cn/shop/',s+'/cart/',s+'/zh/cart/',s+'/zh-cn/cart/',s+'/checkout/',s+'/zh/checkout/',s+'/zh-cn/checkout/',s+'/compare/',s+'/zh/compare/',s+'/zh-cn/compare/']; print(json.dumps({'files':urls}))")
+          PAYLOAD=$(python3 -c "import json; s='${SITE}'; paths=['/','/zh/','/zh-cn/','/shop/','/zh/shop/','/zh-cn/shop/','/cart/','/zh/cart/','/zh-cn/cart/','/checkout/','/zh/checkout/','/zh-cn/checkout/','/compare/','/zh/compare/','/zh-cn/compare/','/llms.txt','/llms-full.txt','/agent/products.md','/agent/compare-10p-vs-10s.md','/agent/apps.md','/agent/troubleshooting.md','/agent/setup.md','/agent/shipping-returns.md','/agent/contact.md','/agent-friendly-sitemap.xml','/svicloud-10p-vs-10s/','/best-svicloud-box-for-chinese-tv-usa/','/yogurt-tv-not-working-upgrade-guide/','/svicloud-box-authenticity-guide/']; print(json.dumps({'files':[s+p for p in paths]}))")
           echo "Purging ${#PAYLOAD} chars of targeted URLs..."
         else
           PAYLOAD='{"purge_everything":true}'

--- a/theme/svicloudtvbox-lumen/functions.php
+++ b/theme/svicloudtvbox-lumen/functions.php
@@ -430,7 +430,7 @@ add_filter('woocommerce_add_to_cart_redirect', function (string $url): string {
     return wc_get_checkout_url();
 });
 
-const SVIC_LITESPEED_PURGE_MARK = 'svic-hero-rating-pill-20260510-11';
+const SVIC_LITESPEED_PURGE_MARK = 'svic-agent-friendly-routes-20260613-01';
 const SVIC_REWRITE_FLUSH_MARK   = 'svic-rewrite-flush-20260407';
 
 add_action('init', function () {


### PR DESCRIPTION
## Summary
- bump the in-theme LiteSpeed purge marker so stale clean-URL redirects are purged after deploy
- add agent-friendly root, Markdown, sitemap, and decision URLs to the Cloudflare targeted purge list

## Validation
- php -l theme/svicloudtvbox-lumen/functions.php
- python3 scripts/validate_agent_resources.py