### PR TITLE
feat(theme): add Father's Day coupon promotion

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,53 @@
+# SVICLOUD Storefront
+
+The SVICLOUD storefront context describes the customer-facing commerce language for promotions, products, and purchase flows.
+
+## Language
+
+**Coupon Promotion**:
+A limited-time offer redeemed by entering a coupon code during checkout.
+_Avoid_: Sale, discount, deal
+
+**Product Model**:
+A named SVICLOUD device variant sold in the storefront.
+_Avoid_: SKU, item, box
+
+**Promotion Window**:
+The calendar period during which a Coupon Promotion can be redeemed.
+_Avoid_: Weekend, campaign dates, sale period
+
+**Promotion Surface**:
+A customer-facing storefront location where a Coupon Promotion is advertised.
+_Avoid_: Ad slot, promo area, placement
+
+**Merchant Promotion**:
+A Google Merchant Center listing that advertises a Coupon Promotion in shopping surfaces.
+_Avoid_: Google ad, feed discount, GMC deal
+
+**Localized Promotion Copy**:
+Customer-facing Coupon Promotion wording written for each storefront language.
+_Avoid_: Translation string, copy variant, banner text
+
+## Relationships
+
+- A **Coupon Promotion** has exactly one public coupon code.
+- A **Coupon Promotion** may apply different discount rates to different **Product Models**.
+- A **Coupon Promotion** can discount multiple eligible **Product Models** in the same customer cart.
+- A **Coupon Promotion** may be limited to one redemption per customer.
+- A **Coupon Promotion** has exactly one **Promotion Window**.
+- A **Coupon Promotion** appears on one or more **Promotion Surfaces** and is redeemed during checkout.
+- A **Merchant Promotion** may advertise only one featured **Product Model** even when the related **Coupon Promotion** covers more than one model.
+- A **Coupon Promotion** has **Localized Promotion Copy** for each supported storefront language.
+
+## Example dialogue
+
+> **Dev:** "Should the Father's Day offer change product prices everywhere?"
+> **Domain expert:** "No — it is a **Coupon Promotion**, so shoppers use the code at checkout."
+
+## Flagged ambiguities
+
+- "Father's Day promotion" was used broadly; resolved: it means a **Coupon Promotion**, not a permanent price change.
+- "One code" was clarified to mean one public coupon code with model-specific discount rates, not separate model-specific codes.
+- "Father's Day weekend" was clarified to include Monday, not only Saturday and Sunday.
+- "Advertise it on the website" was clarified to require a sitewide top banner as the primary **Promotion Surface**.
+- "Add the promotion in Google Merchant Center" was clarified to mean one **Merchant Promotion**; if one discount must be featured, feature the 10S discount.

--- a/scripts/google_merchant_fathers_day_promotion.py
+++ b/scripts/google_merchant_fathers_day_promotion.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Create/update the SVICLOUD Father's Day promotion in Google Merchant Center.
+
+Uses Merchant API REST endpoints with a service-account JSON key.
+Secret file default: secrets/google-merchant-service-account.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+try:
+    from google.oauth2 import service_account
+    from google.auth.transport.requests import AuthorizedSession
+except ImportError as exc:  # pragma: no cover - operator guidance
+    raise SystemExit(
+        "Missing Google auth libraries. Install with: "
+        "python3 -m pip install google-auth requests"
+    ) from exc
+
+
+SCOPE = "https://www.googleapis.com/auth/content"
+ACCOUNT_ID = "5317978135"
+PROMOTION_ID = "dad2026-svic-10s"
+PROMOTION_CODE = "DAD2026"
+TITLE = "Father's Day: 10% off SVICLOUD 10S"
+DESCRIPTION = "Celebrate Dad with a better way to stream. Save 10% on SVICLOUD 10S with code DAD2026."
+DEFAULT_KEY_PATH = "secrets/google-merchant-service-account.json"
+DEFAULT_TIMEZONE = "America/Los_Angeles"
+
+
+class MerchantApiError(RuntimeError):
+    pass
+
+
+def api_request(session: AuthorizedSession, method: str, url: str, **kwargs: Any) -> dict[str, Any]:
+    response = session.request(method, url, timeout=45, **kwargs)
+    if response.status_code >= 400:
+        body = response.text[:2000]
+        raise MerchantApiError(f"{method} {url} failed: HTTP {response.status_code}\n{body}")
+    if not response.text.strip():
+        return {}
+    return response.json()
+
+
+def rfc3339_local(value: str, timezone_name: str) -> str:
+    tz = ZoneInfo(timezone_name)
+    dt = datetime.strptime(value, "%Y-%m-%d %H:%M:%S").replace(tzinfo=tz)
+    return dt.isoformat()
+
+
+def get_session(key_path: str) -> AuthorizedSession:
+    credentials = service_account.Credentials.from_service_account_file(key_path, scopes=[SCOPE])
+    return AuthorizedSession(credentials)
+
+
+def list_data_sources(session: AuthorizedSession, account_id: str) -> list[dict[str, Any]]:
+    url = f"https://merchantapi.googleapis.com/datasources/v1/accounts/{account_id}/dataSources?pageSize=1000"
+    data = api_request(session, "GET", url)
+    return data.get("dataSources", [])
+
+
+def find_or_create_promotion_data_source(
+    session: AuthorizedSession,
+    account_id: str,
+    *,
+    content_language: str,
+    target_country: str,
+    explicit_data_source_id: str | None,
+    create_if_missing: bool,
+) -> str:
+    if explicit_data_source_id:
+        if explicit_data_source_id.startswith("accounts/"):
+            return explicit_data_source_id
+        return f"accounts/{account_id}/dataSources/{explicit_data_source_id}"
+
+    for source in list_data_sources(session, account_id):
+        promo_source = source.get("promotionDataSource") or {}
+        if (
+            promo_source.get("contentLanguage") == content_language
+            and promo_source.get("targetCountry") == target_country
+        ):
+            name = source.get("name")
+            if name:
+                return name
+
+    if not create_if_missing:
+        raise MerchantApiError("No en/US promotion data source found. Pass --data-source-id or allow creation.")
+
+    url = f"https://merchantapi.googleapis.com/datasources/v1/accounts/{account_id}/dataSources"
+    body = {
+        "displayName": "SVICLOUD Promotions API",
+        "promotionDataSource": {
+            "contentLanguage": content_language,
+            "targetCountry": target_country,
+        },
+    }
+    created = api_request(session, "POST", url, json=body)
+    name = created.get("name")
+    if not name:
+        raise MerchantApiError(f"Promotion data source created without a name: {json.dumps(created, indent=2)}")
+    return name
+
+
+def list_products(session: AuthorizedSession, account_id: str) -> list[dict[str, Any]]:
+    products: list[dict[str, Any]] = []
+    page_token = ""
+    while True:
+        url = f"https://merchantapi.googleapis.com/products/v1/accounts/{account_id}/products?pageSize=1000"
+        if page_token:
+            url += f"&pageToken={page_token}"
+        data = api_request(session, "GET", url)
+        products.extend(data.get("products", []))
+        page_token = data.get("nextPageToken", "")
+        if not page_token:
+            return products
+
+
+def product_search_text(product: dict[str, Any]) -> str:
+    attrs = product.get("productAttributes") or {}
+    pieces = [
+        product.get("offerId", ""),
+        product.get("name", ""),
+        attrs.get("title", ""),
+        attrs.get("link", ""),
+        attrs.get("canonicalLink", ""),
+    ]
+    return " ".join(str(piece) for piece in pieces if piece).lower()
+
+
+def find_10s_offer_id(session: AuthorizedSession, account_id: str) -> str | None:
+    products = list_products(session, account_id)
+    for product in products:
+        text = product_search_text(product)
+        if "10s" in text or "svicloud-10s" in text:
+            offer_id = product.get("offerId")
+            if offer_id:
+                return str(offer_id)
+    return None
+
+
+def promotion_body(
+    account_id: str,
+    data_source: str,
+    *,
+    offer_id: str | None,
+    start_time: str,
+    end_time: str,
+) -> dict[str, Any]:
+    attributes: dict[str, Any] = {
+        "productApplicability": "SPECIFIC_PRODUCTS" if offer_id else "ALL_PRODUCTS",
+        "offerType": "GENERIC_CODE",
+        "genericRedemptionCode": PROMOTION_CODE,
+        "longTitle": TITLE,
+        "couponValueType": "PERCENT_OFF",
+        "percentOff": "10",
+        "promotionDestinations": ["SHOPPING_ADS", "FREE_LISTINGS"],
+        "promotionEffectiveTimePeriod": {
+            "startTime": start_time,
+            "endTime": end_time,
+        },
+        "promotionDisplayTimePeriod": {
+            "startTime": start_time,
+            "endTime": end_time,
+        },
+        "promotionUrl": "https://svicloudtvbox.us/shop/",
+    }
+    if offer_id:
+        attributes["itemIdInclusion"] = [offer_id]
+
+    return {
+        "dataSource": data_source,
+        "promotion": {
+            "promotionId": PROMOTION_ID,
+            "contentLanguage": "en",
+            "targetCountry": "US",
+            "redemptionChannel": ["ONLINE"],
+            "attributes": attributes,
+            "customAttributes": [
+                {"name": "svic_description", "value": DESCRIPTION},
+                {"name": "svic_coupon_code", "value": PROMOTION_CODE},
+            ],
+        },
+    }
+
+
+def insert_promotion(session: AuthorizedSession, account_id: str, body: dict[str, Any]) -> dict[str, Any]:
+    url = f"https://merchantapi.googleapis.com/promotions/v1/accounts/{account_id}/promotions:insert"
+    return api_request(session, "POST", url, json=body)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create/update the Father's Day Merchant Center promotion.")
+    parser.add_argument("--account-id", default=os.getenv("GOOGLE_MERCHANT_ACCOUNT_ID", ACCOUNT_ID))
+    parser.add_argument("--key-file", default=os.getenv("GOOGLE_APPLICATION_CREDENTIALS", DEFAULT_KEY_PATH))
+    parser.add_argument("--data-source-id", default=os.getenv("GOOGLE_MERCHANT_PROMOTION_DATA_SOURCE_ID"))
+    parser.add_argument("--timezone", default=os.getenv("SVIC_PROMO_TIMEZONE", DEFAULT_TIMEZONE))
+    parser.add_argument("--start", default="2026-06-19 00:00:00")
+    parser.add_argument("--end", default="2026-06-22 23:59:59")
+    parser.add_argument("--no-create-data-source", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    key_path = Path(args.key_file)
+    if not key_path.exists():
+        raise SystemExit(f"Service account JSON not found: {key_path}")
+
+    session = get_session(str(key_path))
+    data_source = find_or_create_promotion_data_source(
+        session,
+        args.account_id,
+        content_language="en",
+        target_country="US",
+        explicit_data_source_id=args.data_source_id,
+        create_if_missing=not args.no_create_data_source,
+    )
+    offer_id = find_10s_offer_id(session, args.account_id)
+    start_time = rfc3339_local(args.start, args.timezone)
+    end_time = rfc3339_local(args.end, args.timezone)
+    body = promotion_body(args.account_id, data_source, offer_id=offer_id, start_time=start_time, end_time=end_time)
+
+    if args.dry_run:
+        safe_body = json.loads(json.dumps(body))
+        print(json.dumps({"dataSource": data_source, "matched10sOfferId": offer_id, "request": safe_body}, indent=2))
+        return 0
+
+    response = insert_promotion(session, args.account_id, body)
+    print(json.dumps({
+        "status": "submitted",
+        "accountId": args.account_id,
+        "dataSource": data_source,
+        "matched10sOfferId": offer_id,
+        "promotionId": PROMOTION_ID,
+        "promotionName": response.get("name"),
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except MerchantApiError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/theme/svicloudtvbox-lumen/assets/css/bundles.json
+++ b/theme/svicloudtvbox-lumen/assets/css/bundles.json
@@ -5,6 +5,7 @@
     "parts": [
       "00-tokens.css",
       "05-announcement-bar.css",
+      "05a-promotion-bar.css",
       "06-recent-shipments-strip.css",
       "12-header-base.css",
       "13-header-actions.css",

--- a/theme/svicloudtvbox-lumen/assets/css/parts/05a-promotion-bar.css
+++ b/theme/svicloudtvbox-lumen/assets/css/parts/05a-promotion-bar.css
@@ -1,0 +1,167 @@
+/* ============================================================
+   Promotion Bar
+   Polished site-wide campaign strip above the main header.
+   ============================================================ */
+
+.svic-promo-bar {
+  position: relative;
+  z-index: 220;
+  width: 100%;
+  padding: 0.64rem clamp(1rem, 4vw, 2.5rem);
+  color: var(--lumen-text-primary);
+  background:
+    radial-gradient(circle at 10% 0%, rgba(255, 185, 99, 0.28), transparent 32%),
+    radial-gradient(circle at 88% 12%, rgba(94, 230, 208, 0.22), transparent 34%),
+    linear-gradient(92deg, #07152d 0%, #102a51 52%, #07152d 100%);
+  border-bottom: 1px solid rgba(126, 246, 227, 0.18);
+  box-shadow: 0 16px 38px rgba(3, 10, 24, 0.22);
+  font-family: var(--font-primary);
+}
+
+.svic-promo-bar__inner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.68rem;
+  width: min(1180px, 100%);
+  margin: 0 auto;
+  line-height: 1.35;
+  text-align: center;
+  flex-wrap: wrap;
+}
+
+.svic-promo-bar__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.72rem;
+  padding: 0.24rem 0.62rem;
+  border: 1px solid rgba(255, 185, 99, 0.48);
+  border-radius: 999px;
+  background: rgba(255, 185, 99, 0.14);
+  color: #ffe1ad;
+  font-size: 0.76rem;
+  font-weight: 760;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.svic-promo-bar__message {
+  color: rgba(246, 250, 255, 0.96);
+  font-size: clamp(0.88rem, 0.82rem + 0.25vw, 1rem);
+  font-weight: 640;
+}
+
+.svic-promo-bar__offers {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.38rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.svic-promo-bar__chip,
+.svic-promo-bar__code {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1.78rem;
+  padding: 0.24rem 0.62rem;
+  border-radius: 999px;
+  white-space: nowrap;
+  font-size: 0.82rem;
+  font-weight: 760;
+}
+
+.svic-promo-bar__chip {
+  color: #dffdf8;
+  background: rgba(94, 230, 208, 0.13);
+  border: 1px solid rgba(94, 230, 208, 0.28);
+}
+
+.svic-promo-bar__chip--strong {
+  color: #061328;
+  background: linear-gradient(135deg, #7ef6e3, #ffcf8a);
+  border-color: rgba(255, 255, 255, 0.18);
+  box-shadow: 0 10px 24px rgba(94, 230, 208, 0.18);
+}
+
+.svic-promo-bar__code {
+  color: #fff6e8;
+  background: rgba(255, 255, 255, 0.09);
+  border: 1px dashed rgba(255, 225, 173, 0.62);
+  font-family: var(--font-accent);
+  letter-spacing: 0.045em;
+}
+
+.svic-promo-bar__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  padding: 0.34rem 0.82rem;
+  border-radius: 999px;
+  color: rgba(3, 14, 31, 0.96);
+  background: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  box-shadow: 0 12px 28px rgba(4, 12, 30, 0.22);
+  font-size: 0.84rem;
+  font-weight: 820;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: transform 0.16s ease, box-shadow 0.16s ease, background 0.16s ease;
+}
+
+.svic-promo-bar__cta:hover,
+.svic-promo-bar__cta:focus-visible {
+  color: rgba(3, 14, 31, 0.98);
+  background: #f8fbff;
+  box-shadow: 0 16px 34px rgba(4, 12, 30, 0.28);
+  transform: translateY(-1px);
+}
+
+.svic-promo-bar__cta:focus-visible {
+  outline: 3px solid rgba(126, 246, 227, 0.72);
+  outline-offset: 3px;
+}
+
+@media (max-width: 820px) {
+  .svic-promo-bar {
+    padding-block: 0.72rem;
+  }
+
+  .svic-promo-bar__inner {
+    gap: 0.52rem;
+  }
+
+  .svic-promo-bar__message {
+    flex-basis: 100%;
+  }
+}
+
+@media (max-width: 520px) {
+  .svic-promo-bar {
+    padding: 0.78rem 0.9rem;
+  }
+
+  .svic-promo-bar__inner {
+    align-items: stretch;
+  }
+
+  .svic-promo-bar__eyebrow,
+  .svic-promo-bar__offers,
+  .svic-promo-bar__code,
+  .svic-promo-bar__cta {
+    width: 100%;
+  }
+
+  .svic-promo-bar__eyebrow,
+  .svic-promo-bar__code,
+  .svic-promo-bar__cta {
+    justify-content: center;
+  }
+
+  .svic-promo-bar__chip {
+    flex: 1 1 9.25rem;
+  }
+}

--- a/theme/svicloudtvbox-lumen/assets/css/style.css
+++ b/theme/svicloudtvbox-lumen/assets/css/style.css
@@ -40,6 +40,28 @@ select option{color:#1a1a2e;background:#fff}
 @media(max-width:480px){.svic-announcement-bar{padding:8px 1rem}
 .svic-announcement-bar__inner{gap:0.35rem}
 }
+.svic-promo-bar{position:relative;z-index:220;width:100%;padding:0.64rem clamp(1rem,4vw,2.5rem);color:var(--lumen-text-primary);background:radial-gradient(circle at 10% 0%,rgba(255,185,99,0.28),transparent 32%),radial-gradient(circle at 88% 12%,rgba(94,230,208,0.22),transparent 34%),linear-gradient(92deg,#07152d 0%,#102a51 52%,#07152d 100%);border-bottom:1px solid rgba(126,246,227,0.18);box-shadow:0 16px 38px rgba(3,10,24,0.22);font-family:var(--font-primary)}
+.svic-promo-bar__inner{display:flex;align-items:center;justify-content:center;gap:0.68rem;width:min(1180px,100%);margin:0 auto;line-height:1.35;text-align:center;flex-wrap:wrap}
+.svic-promo-bar__eyebrow{display:inline-flex;align-items:center;min-height:1.72rem;padding:0.24rem 0.62rem;border:1px solid rgba(255,185,99,0.48);border-radius:999px;background:rgba(255,185,99,0.14);color:#ffe1ad;font-size:0.76rem;font-weight:760;letter-spacing:0.07em;text-transform:uppercase;white-space:nowrap}
+.svic-promo-bar__message{color:rgba(246,250,255,0.96);font-size:clamp(0.88rem,0.82rem+0.25vw,1rem);font-weight:640}
+.svic-promo-bar__offers{display:inline-flex;align-items:center;gap:0.38rem;flex-wrap:wrap;justify-content:center}
+.svic-promo-bar__chip,.svic-promo-bar__code{display:inline-flex;align-items:center;justify-content:center;min-height:1.78rem;padding:0.24rem 0.62rem;border-radius:999px;white-space:nowrap;font-size:0.82rem;font-weight:760}
+.svic-promo-bar__chip{color:#dffdf8;background:rgba(94,230,208,0.13);border:1px solid rgba(94,230,208,0.28)}
+.svic-promo-bar__chip--strong{color:#061328;background:linear-gradient(135deg,#7ef6e3,#ffcf8a);border-color:rgba(255,255,255,0.18);box-shadow:0 10px 24px rgba(94,230,208,0.18)}
+.svic-promo-bar__code{color:#fff6e8;background:rgba(255,255,255,0.09);border:1px dashed rgba(255,225,173,0.62);font-family:var(--font-accent);letter-spacing:0.045em}
+.svic-promo-bar__cta{display:inline-flex;align-items:center;justify-content:center;min-height:2rem;padding:0.34rem 0.82rem;border-radius:999px;color:rgba(3,14,31,0.96);background:#ffffff;border:1px solid rgba(255,255,255,0.72);box-shadow:0 12px 28px rgba(4,12,30,0.22);font-size:0.84rem;font-weight:820;text-decoration:none;white-space:nowrap;transition:transform 0.16s ease,box-shadow 0.16s ease,background 0.16s ease}
+.svic-promo-bar__cta:hover,.svic-promo-bar__cta:focus-visible{color:rgba(3,14,31,0.98);background:#f8fbff;box-shadow:0 16px 34px rgba(4,12,30,0.28);transform:translateY(-1px)}
+.svic-promo-bar__cta:focus-visible{outline:3px solid rgba(126,246,227,0.72);outline-offset:3px}
+@media(max-width:820px){.svic-promo-bar{padding-block:0.72rem}
+.svic-promo-bar__inner{gap:0.52rem}
+.svic-promo-bar__message{flex-basis:100%}
+}
+@media(max-width:520px){.svic-promo-bar{padding:0.78rem 0.9rem}
+.svic-promo-bar__inner{align-items:stretch}
+.svic-promo-bar__eyebrow,.svic-promo-bar__offers,.svic-promo-bar__code,.svic-promo-bar__cta{width:100%}
+.svic-promo-bar__eyebrow,.svic-promo-bar__code,.svic-promo-bar__cta{justify-content:center}
+.svic-promo-bar__chip{flex:1 1 9.25rem}
+}
 .svic-recent-shipments{position:relative;z-index:5;background:linear-gradient(90deg,rgba(5,18,44,0.98) 0%,rgba(8,28,60,0.94) 50%,rgba(9,36,70,0.92) 100%);border-top:1px solid rgba(255,255,255,0.04);border-bottom:1px solid rgba(94,230,208,0.14);box-shadow:inset 0 1px 0 rgba(255,255,255,0.04);color:rgba(240,246,255,0.94)}
 .svic-recent-shipments__inner{width:100%;max-width:none;margin:0;padding:0.62rem clamp(0.75rem,1.5vw,1.5rem);display:flex;align-items:center;gap:clamp(0.65rem,0.85vw,0.95rem);min-width:0;box-sizing:border-box}
 .svic-recent-shipments__label{display:inline-flex;align-items:center;gap:0.45rem;flex:0 1 auto;min-width:0;max-width:clamp(11.25rem,14vw,13rem);color:rgba(210,242,255,0.9);font-size:clamp(0.62rem,0.6rem+0.12vw,0.7rem);font-weight:700;letter-spacing:0.075em;text-transform:uppercase}

--- a/theme/svicloudtvbox-lumen/functions.php
+++ b/theme/svicloudtvbox-lumen/functions.php
@@ -33,6 +33,11 @@ if (!defined('SVIC_RECENT_SHIPMENTS_ENABLED')) {
  * Called from header.php just before <header>.
  */
 function svic_render_announcement_bar(): void {
+    if (function_exists('svic_render_fathers_day_promotion_bar') && svic_is_fathers_day_promotion_visible()) {
+        svic_render_fathers_day_promotion_bar();
+        return;
+    }
+
     if (!SVIC_ANNOUNCEMENT_ENABLED) {
         return;
     }
@@ -468,6 +473,7 @@ require_once get_template_directory() . '/inc/class-svic-locale-resolver.php';
 require_once get_template_directory() . '/inc/guides-data.php';
 require_once get_template_directory() . '/inc/theme-maintenance.php';
 require_once get_template_directory() . '/inc/helpers-svic.php';
+require_once get_template_directory() . '/inc/fathers-day-promotion.php';
 require_once get_template_directory() . '/inc/virtual-page-state.php';
 require_once get_template_directory() . '/inc/agent-resources.php';
 require_once get_template_directory() . '/inc/guide-routes.php';

--- a/theme/svicloudtvbox-lumen/inc/fathers-day-promotion.php
+++ b/theme/svicloudtvbox-lumen/inc/fathers-day-promotion.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * Father's Day 2026 coupon promotion automation.
+ */
+
+declare(strict_types=1);
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!defined('SVIC_FATHERS_DAY_PROMO_CODE')) {
+    define('SVIC_FATHERS_DAY_PROMO_CODE', 'DAD2026');
+}
+
+if (!defined('SVIC_FATHERS_DAY_PROMO_START')) {
+    define('SVIC_FATHERS_DAY_PROMO_START', '2026-06-19 00:00:00');
+}
+
+if (!defined('SVIC_FATHERS_DAY_PROMO_END')) {
+    define('SVIC_FATHERS_DAY_PROMO_END', '2026-06-22 23:59:59');
+}
+
+if (!defined('SVIC_FATHERS_DAY_PROMO_SYNC_MARK')) {
+    define('SVIC_FATHERS_DAY_PROMO_SYNC_MARK', '20260618-01');
+}
+
+if (!function_exists('svic_fathers_day_promotion_code')) {
+    function svic_fathers_day_promotion_code(): string
+    {
+        return (string) SVIC_FATHERS_DAY_PROMO_CODE;
+    }
+}
+
+if (!function_exists('svic_fathers_day_promotion_products')) {
+    function svic_fathers_day_promotion_products(): array
+    {
+        return [
+            'svicloud-10p-plus' => [
+                'model' => 'SVICLOUD 10P+',
+                'rate'  => 5.0,
+            ],
+            'svicloud-10s' => [
+                'model' => 'SVICLOUD 10S',
+                'rate'  => 10.0,
+            ],
+        ];
+    }
+}
+
+if (!function_exists('svic_fathers_day_promotion_timezone')) {
+    function svic_fathers_day_promotion_timezone(): DateTimeZone
+    {
+        if (function_exists('wp_timezone')) {
+            return wp_timezone();
+        }
+
+        $timezone_string = get_option('timezone_string');
+        if (is_string($timezone_string) && $timezone_string !== '') {
+            return new DateTimeZone($timezone_string);
+        }
+
+        return new DateTimeZone('UTC');
+    }
+}
+
+if (!function_exists('svic_fathers_day_promotion_window')) {
+    function svic_fathers_day_promotion_window(): array
+    {
+        $timezone = svic_fathers_day_promotion_timezone();
+
+        return [
+            'start' => new DateTimeImmutable((string) SVIC_FATHERS_DAY_PROMO_START, $timezone),
+            'end'   => new DateTimeImmutable((string) SVIC_FATHERS_DAY_PROMO_END, $timezone),
+        ];
+    }
+}
+
+if (!function_exists('svic_is_fathers_day_promotion_active')) {
+    function svic_is_fathers_day_promotion_active(?DateTimeImmutable $now = null): bool
+    {
+        $window = svic_fathers_day_promotion_window();
+        $now    = $now ?: new DateTimeImmutable('now', svic_fathers_day_promotion_timezone());
+
+        return $now >= $window['start'] && $now <= $window['end'];
+    }
+}
+
+if (!function_exists('svic_is_fathers_day_promotion_preview')) {
+    function svic_is_fathers_day_promotion_preview(): bool
+    {
+        if (!is_user_logged_in() || !current_user_can('manage_options')) {
+            return false;
+        }
+
+        $preview = isset($_GET['svic_preview_promo']) ? sanitize_text_field(wp_unslash($_GET['svic_preview_promo'])) : '';
+        return strtolower($preview) === strtolower(svic_fathers_day_promotion_code());
+    }
+}
+
+if (!function_exists('svic_is_fathers_day_promotion_visible')) {
+    function svic_is_fathers_day_promotion_visible(): bool
+    {
+        return svic_is_fathers_day_promotion_active() || svic_is_fathers_day_promotion_preview();
+    }
+}
+
+if (!function_exists('svic_fathers_day_promotion_product_ids')) {
+    function svic_fathers_day_promotion_product_ids(): array
+    {
+        $ids = [];
+
+        if (!class_exists('WooCommerce')) {
+            return $ids;
+        }
+
+        foreach (array_keys(svic_fathers_day_promotion_products()) as $slug) {
+            $post = get_page_by_path($slug, OBJECT, 'product');
+            if ($post instanceof WP_Post) {
+                $ids[$slug] = (int) $post->ID;
+            }
+        }
+
+        return $ids;
+    }
+}
+
+if (!function_exists('svic_fathers_day_promotion_rate_for_product')) {
+    function svic_fathers_day_promotion_rate_for_product($product): float
+    {
+        if (!$product instanceof WC_Product) {
+            return 0.0;
+        }
+
+        $product_ids = svic_fathers_day_promotion_product_ids();
+        $product_id  = (int) $product->get_id();
+        $parent_id   = method_exists($product, 'get_parent_id') ? (int) $product->get_parent_id() : 0;
+
+        foreach (svic_fathers_day_promotion_products() as $slug => $config) {
+            $eligible_id = (int) ($product_ids[$slug] ?? 0);
+            if ($eligible_id > 0 && ($product_id === $eligible_id || $parent_id === $eligible_id)) {
+                return (float) ($config['rate'] ?? 0.0);
+            }
+        }
+
+        return 0.0;
+    }
+}
+
+if (!function_exists('svic_fathers_day_promotion_cart_has_eligible_item')) {
+    function svic_fathers_day_promotion_cart_has_eligible_item(): bool
+    {
+        if (!function_exists('WC') || !WC()->cart) {
+            return false;
+        }
+
+        foreach (WC()->cart->get_cart() as $cart_item) {
+            $product = $cart_item['data'] ?? null;
+            if (svic_fathers_day_promotion_rate_for_product($product) > 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+if (!function_exists('svic_sync_fathers_day_promotion_coupon')) {
+    function svic_sync_fathers_day_promotion_coupon(): void
+    {
+        if (!class_exists('WC_Coupon') || !function_exists('wc_get_coupon_id_by_code') || wp_installing()) {
+            return;
+        }
+
+        $code      = svic_fathers_day_promotion_code();
+        $coupon_id = wc_get_coupon_id_by_code($code);
+        $mark      = get_option('svic_fathers_day_promotion_coupon_sync_mark');
+
+        if ($mark === SVIC_FATHERS_DAY_PROMO_SYNC_MARK && $coupon_id) {
+            return;
+        }
+
+        $coupon = $coupon_id ? new WC_Coupon($coupon_id) : new WC_Coupon();
+        $window = svic_fathers_day_promotion_window();
+
+        $coupon->set_code($code);
+        $coupon->set_description('Father\'s Day 2026: 5% off SVICLOUD 10P+ and 10% off SVICLOUD 10S.');
+        $coupon->set_discount_type('percent');
+        $coupon->set_amount(10);
+        $coupon->set_individual_use(true);
+        $coupon->set_usage_limit(0);
+        $coupon->set_usage_limit_per_user(1);
+        $coupon->set_minimum_amount('');
+        $coupon->set_product_ids(array_values(svic_fathers_day_promotion_product_ids()));
+        $coupon->set_exclude_sale_items(false);
+        $coupon->set_free_shipping(false);
+
+        if (class_exists('WC_DateTime')) {
+            $coupon->set_date_expires(new WC_DateTime($window['end']->format('Y-m-d H:i:s'), svic_fathers_day_promotion_timezone()));
+        }
+
+        $coupon->save();
+        update_option('svic_fathers_day_promotion_coupon_sync_mark', SVIC_FATHERS_DAY_PROMO_SYNC_MARK, false);
+    }
+}
+
+add_action('init', 'svic_sync_fathers_day_promotion_coupon', 40);
+
+add_filter('woocommerce_coupon_is_valid', function ($valid, $coupon) {
+    if (!$coupon instanceof WC_Coupon || strtolower((string) $coupon->get_code()) !== strtolower(svic_fathers_day_promotion_code())) {
+        return $valid;
+    }
+
+    if (!svic_is_fathers_day_promotion_active()) {
+        throw new Exception(svic_translate('promotion.fathers_day.coupon_not_active'));
+    }
+
+    if (!svic_fathers_day_promotion_cart_has_eligible_item()) {
+        throw new Exception(svic_translate('promotion.fathers_day.coupon_not_eligible'));
+    }
+
+    return $valid;
+}, 10, 2);
+
+add_filter('woocommerce_coupon_is_valid_for_product', function ($valid, $product, $coupon, $values) {
+    if (!$coupon instanceof WC_Coupon || strtolower((string) $coupon->get_code()) !== strtolower(svic_fathers_day_promotion_code())) {
+        return $valid;
+    }
+
+    return svic_fathers_day_promotion_rate_for_product($product) > 0;
+}, 10, 4);
+
+add_filter('woocommerce_coupon_get_discount_amount', function ($discount, $discounting_amount, $cart_item, $single, $coupon) {
+    if (!$coupon instanceof WC_Coupon || strtolower((string) $coupon->get_code()) !== strtolower(svic_fathers_day_promotion_code())) {
+        return $discount;
+    }
+
+    $product = is_array($cart_item) ? ($cart_item['data'] ?? null) : null;
+    $rate    = svic_fathers_day_promotion_rate_for_product($product);
+    if ($rate <= 0) {
+        return 0;
+    }
+
+    $amount = (float) $discounting_amount * ($rate / 100);
+    if (function_exists('wc_round_discount') && function_exists('wc_get_rounding_precision')) {
+        return wc_round_discount($amount, wc_get_rounding_precision());
+    }
+
+    return round($amount, 2);
+}, 10, 5);
+
+if (!function_exists('svic_render_fathers_day_promotion_bar')) {
+    function svic_render_fathers_day_promotion_bar(): void
+    {
+        if (!svic_is_fathers_day_promotion_visible()) {
+            return;
+        }
+
+        $code    = svic_fathers_day_promotion_code();
+        $shopUrl = function_exists('svic_url_with_lang') ? svic_url_with_lang(home_url('/shop/')) : home_url('/shop/');
+        ?>
+        <div class="svic-promo-bar svic-promo-bar--fathers-day" role="region" aria-label="<?php echo svic_translate_attr('promotion.fathers_day.aria_label'); ?>">
+            <div class="svic-promo-bar__inner">
+                <span class="svic-promo-bar__eyebrow"><?php echo svic_translate_html('promotion.fathers_day.eyebrow'); ?></span>
+                <span class="svic-promo-bar__message"><?php echo svic_translate_html('promotion.fathers_day.message'); ?></span>
+                <span class="svic-promo-bar__offers" aria-label="<?php echo svic_translate_attr('promotion.fathers_day.offers_label'); ?>">
+                    <span class="svic-promo-bar__chip"><?php echo svic_translate_html('promotion.fathers_day.offer_10p'); ?></span>
+                    <span class="svic-promo-bar__chip svic-promo-bar__chip--strong"><?php echo svic_translate_html('promotion.fathers_day.offer_10s'); ?></span>
+                </span>
+                <span class="svic-promo-bar__code"><?php echo svic_translate_html('promotion.fathers_day.code_label', ['code' => $code]); ?></span>
+                <a class="svic-promo-bar__cta" href="<?php echo esc_url($shopUrl); ?>"><?php echo svic_translate_html('promotion.fathers_day.cta'); ?></a>
+            </div>
+        </div>
+        <?php
+    }
+}

--- a/theme/svicloudtvbox-lumen/lang/en_US.php
+++ b/theme/svicloudtvbox-lumen/lang/en_US.php
@@ -11,6 +11,21 @@ return [
         'cta_url' => '',
     ],
 
+    'promotion' => [
+        'fathers_day' => [
+            'aria_label'          => 'Father\'s Day promotion',
+            'eyebrow'             => 'Father\'s Day Weekend',
+            'message'             => 'Celebrate Dad with a better way to stream.',
+            'offers_label'        => 'Father\'s Day eligible offers',
+            'offer_10p'           => '10P+ saves 5%',
+            'offer_10s'           => '10S saves 10%',
+            'code_label'          => 'Code {{code}}',
+            'cta'                 => 'Shop the offer',
+            'coupon_not_active'   => 'DAD2026 is valid from June 19 through June 22, 2026.',
+            'coupon_not_eligible' => 'DAD2026 applies to SVICLOUD 10P+ and SVICLOUD 10S only.',
+        ],
+    ],
+
     'recent_shipments' => [
         'badge'                  => 'Recent Shipments',
         'aria_label'             => 'Recent shipments and estimated delivery windows',

--- a/theme/svicloudtvbox-lumen/lang/zh_CN.php
+++ b/theme/svicloudtvbox-lumen/lang/zh_CN.php
@@ -12,6 +12,21 @@ $overrides = [
         'cta_url' => '',
     ],
 
+    'promotion' => [
+        'fathers_day' => [
+            'aria_label'          => '父亲节优惠',
+            'eyebrow'             => '父亲节周末',
+            'message'             => '用更好的流媒体体验庆祝父亲节。',
+            'offers_label'        => '父亲节适用优惠',
+            'offer_10p'           => '10P+ 省 5%',
+            'offer_10s'           => '10S 省 10%',
+            'code_label'          => '代码 {{code}}',
+            'cta'                 => '选购优惠',
+            'coupon_not_active'   => 'DAD2026 适用日期为 2026 年 6 月 19 日至 6 月 22 日。',
+            'coupon_not_eligible' => 'DAD2026 仅适用于 SVICLOUD 10P+ 与 SVICLOUD 10S。',
+        ],
+    ],
+
     'recent_shipments' => [
         'badge'                  => '近期出货',
         'aria_label'             => '近期出货与预估送达时程',

--- a/theme/svicloudtvbox-lumen/lang/zh_TW.php
+++ b/theme/svicloudtvbox-lumen/lang/zh_TW.php
@@ -11,6 +11,21 @@ return [
         'cta_url' => '',
     ],
 
+    'promotion' => [
+        'fathers_day' => [
+            'aria_label'          => '父親節優惠',
+            'eyebrow'             => '父親節週末',
+            'message'             => '用更好的串流體驗慶祝父親節。',
+            'offers_label'        => '父親節適用優惠',
+            'offer_10p'           => '10P+ 省 5%',
+            'offer_10s'           => '10S 省 10%',
+            'code_label'          => '代碼 {{code}}',
+            'cta'                 => '選購優惠',
+            'coupon_not_active'   => 'DAD2026 適用日期為 2026 年 6 月 19 日至 6 月 22 日。',
+            'coupon_not_eligible' => 'DAD2026 僅適用於 SVICLOUD 10P+ 與 SVICLOUD 10S。',
+        ],
+    ],
+
     'recent_shipments' => [
         'badge'                  => '近期出貨',
         'aria_label'             => '近期出貨與預估送達時程',


### PR DESCRIPTION
## Summary
- Add Father's Day sitewide promo banner with localized EN/zh copy
- Auto-create/enforce DAD2026 WooCommerce coupon with 5% off 10P+ and 10% off 10S
- Add Google Merchant Center promotion automation script and domain glossary

## Verification
- PHP lint for theme files
- Python compile for Merchant Center script
- CSS bundle build for svicloudtvbox-lumen
- Local banner/coupon checked; Merchant Center promotion shows policy/SKU approved and final state pending

## Deployment notes / rollback
- Deploy theme after merge with scripts/deploy-theme.sh
- Roll back by reverting this PR; Merchant Center promotion can be paused/deleted in GMC if needed
