### PR TITLE
fix(actions): use robust deploy script for manual production deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,65 +20,30 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: 🏗️ Build CSS bundles
+      - name: 🧪 PHP syntax check
         run: |
-          cd theme/svicloudtvbox-lumen
-          python3 ../../scripts/build_css.py
-          echo "✅ CSS bundles built"
+          sudo apt-get update -y --quiet
+          sudo apt-get install -y --quiet php-cli
+          find theme/svicloudtvbox-lumen -name '*.php' -exec php -l {} \;
 
-      - name: 🚀 Deploy changed files via FTP
+      - name: 🏗️ Build CSS bundles
+        run: python3 scripts/build_css.py --theme svicloudtvbox-lumen
+
+      - name: 🚀 Deploy theme to Hostinger
         env:
           FTP_HOST: ${{ secrets.FTP_HOST }}
           FTP_USER: ${{ secrets.FTP_USER }}
           FTP_PASS: ${{ secrets.FTP_PASS }}
+          FTP_PROTOCOL: ftps
+          FTP_SKIP_SAME_SIZE: "0"
+          LOCAL_THEME_DIR: theme/svicloudtvbox-lumen
+          REMOTE_THEME_DIR: public_html/wp-content/themes/svicloudtvbox-lumen
         run: |
-          REMOTE_BASE="ftp://${FTP_HOST}:21/wp-content/themes/svicloudtvbox-lumen"
-          LOCAL_BASE="theme/svicloudtvbox-lumen"
-
-          UPLOAD_ERRORS=0
-
-          upload() {
-            local file="$1"
-            echo "  Uploading: $file"
-            HTTP_CODE=$(curl -s --ftp-ssl --insecure \
-              -u "${FTP_USER}:${FTP_PASS}" \
-              -T "${LOCAL_BASE}/${file}" \
-              "${REMOTE_BASE}/${file}" \
-              -w "%{http_code}" -o /dev/null)
-            EXIT_CODE=$?
-            if [[ $EXIT_CODE -ne 0 ]]; then
-              echo "  ⚠️ WARN: failed to upload $file (curl exit $EXIT_CODE, ftp $HTTP_CODE) — continuing"
-              UPLOAD_ERRORS=$((UPLOAD_ERRORS + 1))
-            else
-              echo "  ✅ $file → $HTTP_CODE"
-            fi
-          }
-
-          echo "📁 Uploading PHP files..."
-          for f in $(find ${LOCAL_BASE} -maxdepth 1 -name "*.php" | sed "s|${LOCAL_BASE}/||"); do
-            upload "$f"
-          done
-
-          echo "📁 Uploading inc/ files..."
-          for f in $(find ${LOCAL_BASE}/inc -name "*.php" | sed "s|${LOCAL_BASE}/||"); do
-            upload "$f"
-          done
-
-          echo "📁 Uploading lang/ files..."
-          for f in $(find ${LOCAL_BASE}/lang -name "*.php" 2>/dev/null | sed "s|${LOCAL_BASE}/||"); do
-            upload "$f"
-          done
-
-          echo "📁 Uploading CSS bundles..."
-          for f in $(find ${LOCAL_BASE}/assets/css -maxdepth 1 -name "*.css" | sed "s|${LOCAL_BASE}/||"); do
-            upload "$f"
-          done
-
-          if [[ $UPLOAD_ERRORS -gt 0 ]]; then
-            echo "⚠️ $UPLOAD_ERRORS file(s) failed to upload — cache purge will still run"
-          else
-            echo "✅ All files uploaded"
-          fi
+          python3 scripts/deploy_theme.py \
+            --protocol ftps \
+            --local-dir "$LOCAL_THEME_DIR" \
+            --remote-root "$REMOTE_THEME_DIR" \
+            --bust-cache
 
       - name: 🧹 Purge CDN Caches
         uses: ./.github/actions/purge-caches
@@ -94,15 +59,25 @@ jobs:
         env:
           SITE_URL: ${{ secrets.SITE_URL }}
         run: |
-          echo "Checking site is up..."
-          STATUS=$(curl -sI -L --max-time 15 \
-            -A "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" \
-            "${SITE_URL}" | grep "^HTTP/" | tail -1 | awk '{print $2}')
-          echo "Homepage status: $STATUS"
-          # 200 = OK, 301/302 = redirect (also fine), 403 = Cloudflare bot check (site IS up)
-          if [[ "$STATUS" == "200" || "$STATUS" == "301" || "$STATUS" == "302" || "$STATUS" == "403" ]]; then
-            echo "✅ Site is live (${STATUS})"
-          else
-            echo "⚠️ Site returned unexpected status $STATUS — verify manually at ${SITE_URL}"
-            exit 1
-          fi
+          python3 - <<'PY'
+          import os
+          import sys
+          import urllib.request
+
+          site_url = os.environ.get('SITE_URL') or 'https://svicloudtvbox.us/'
+          request = urllib.request.Request(
+              site_url,
+              headers={'User-Agent': 'Mozilla/5.0 GitHub-Actions Deploy Verify'},
+          )
+          try:
+              with urllib.request.urlopen(request, timeout=20) as response:
+                  status = response.getcode()
+          except Exception as exc:
+              print(f'Verification failed: {exc}', file=sys.stderr)
+              raise SystemExit(1)
+
+          print(f'Homepage status: {status}')
+          if status not in {200, 301, 302, 403}:
+              raise SystemExit(f'Unexpected status {status}')
+          print('✅ Site is live')
+          PY


### PR DESCRIPTION
## Summary
- Replace the manual Deploy to Production workflow's custom curl FTP loop with the maintained deploy_theme.py FTPS deploy path
- Add PHP syntax check and keep CSS build before deploy
- Keep cache purge and site verification

## Verification
- Parsed workflow YAML locally
- Secret scan of diff only found expected GitHub secret references

## Why
- Earlier deploy failure was FTPS connection timeout in the older workflow path; using the same robust deploy script as the successful push deploy keeps retries and behavior consistent.
