### PR TITLE
fix(contact): update support phone number to 152-064-17021

### DIFF
--- a/theme/svicloudtvbox-lumen/lang/en_US.php
+++ b/theme/svicloudtvbox-lumen/lang/en_US.php
@@ -71,9 +71,10 @@ return [
             'title' => 'Contact methods',
             'items' => [
                 'phone' => [
-                    'label' => 'SMS / Phone',
-                    'value' => '702-389-3416',
-                    'cta'   => 'Text or call now',
+                    'label' => '',
+                    'value' => '152-064-17021',
+                    'cta'   => '',
+
                 ],
                 'email' => [
                     'label' => 'Email',
@@ -665,7 +666,8 @@ return [
                 ],
                 'phone' => [
                     'label'       => 'Phone',
-                    'placeholder' => '702-389-3416',
+                    'placeholder' => '152-064-17021',
+
                 ],
                 'order' => [
                     'label'       => 'Order number',

--- a/theme/svicloudtvbox-lumen/lang/zh_TW.php
+++ b/theme/svicloudtvbox-lumen/lang/zh_TW.php
@@ -237,7 +237,8 @@ return [
                 ],
                 'phone' => [
                     'label'       => '電話',
-                    'placeholder' => '702-389-3416',
+                    'placeholder' => '152-064-17021',
+
                 ],
                 'order' => [
                     'label'       => '訂單編號',
@@ -311,9 +312,10 @@ return [
             'title' => '聯絡方式',
             'items' => [
                 'phone' => [
-                    'label' => '電話／簡訊',
-                    'value' => '702-389-3416',
-                    'cta'   => '撥打或傳送簡訊',
+                    'label' => '',
+                    'value' => '152-064-17021',
+                    'cta'   => '',
+
                 ],
                 'email' => [
                     'label' => 'Email',

--- a/theme/svicloudtvbox-lumen/page-contact.php
+++ b/theme/svicloudtvbox-lumen/page-contact.php
@@ -109,9 +109,9 @@ $faq_copy = svic_translate_rich('contact.faq.copy', [
             <span aria-hidden="true"></span>
           </div>
           <div class="contact-card__content">
-            <span class="contact-card__label"><?php echo $label; ?></span>
+            <?php if ($label) : ?><span class="contact-card__label"><?php echo $label; ?></span><?php endif; ?>
             <span class="contact-card__value"><?php echo $value; ?></span>
-            <a class="contact-card__cta" href="<?php echo esc_url($href); ?>"><?php echo $cta; ?></a>
+            <?php if ($cta) : ?><a class="contact-card__cta" href="<?php echo esc_url($href); ?>"><?php echo $cta; ?></a><?php endif; ?>
           </div>
         </article>
       <?php endforeach; ?>


### PR DESCRIPTION
## What
- Updates the support phone number from **702-398-3416** to **152-064-17021**
- Removes descriptive label text ("SMS / Phone", "電話／簡訊") and CTA text ("Text or call now", "撥打或傳送簡訊") so only the number shows
- Conditionally renders the label and CTA spans in the contact template so empty strings don't produce empty elements

## Files changed
- `theme/svicloudtvbox-lumen/lang/en_US.php` — contact channels phone value + support form placeholder
- `theme/svicloudtvbox-lumen/lang/zh_TW.php` — same updates for Chinese
- `theme/svicloudtvbox-lumen/page-contact.php` — conditional render for label/cta