### PR TITLE
fix(contact): clean Phone label, remove SMS from support number

### DIFF
--- a/theme/svicloudtvbox-lumen/lang/en_US.php
+++ b/theme/svicloudtvbox-lumen/lang/en_US.php
@@ -71,7 +71,7 @@ return [
             'title' => 'Contact methods',
             'items' => [
                 'phone' => [
-                    'label' => '',
+                    'label' => 'Phone',
                     'value' => '152-064-17021',
                     'cta'   => '',
 

--- a/theme/svicloudtvbox-lumen/lang/zh_TW.php
+++ b/theme/svicloudtvbox-lumen/lang/zh_TW.php
@@ -312,7 +312,7 @@ return [
             'title' => '聯絡方式',
             'items' => [
                 'phone' => [
-                    'label' => '',
+                    'label' => '電話',
                     'value' => '152-064-17021',
                     'cta'   => '',
 


### PR DESCRIPTION
Changes label from blank to clean "Phone" (EN) / "電話" (ZH) — removes SMS/簡訊 from the display while keeping a simple label.