### PR TITLE
Enable July 4 promotion

### DIFF
--- a/theme/svicloudtvbox-lumen/inc/active-promotion.php
+++ b/theme/svicloudtvbox-lumen/inc/active-promotion.php
@@ -14,23 +14,23 @@ if (!defined('ABSPATH')) {
 }
 
 if (!defined('SVIC_PROMOTION_ENABLED')) {
-    define('SVIC_PROMOTION_ENABLED', false);
+    define('SVIC_PROMOTION_ENABLED', true);
 }
 
 if (!defined('SVIC_PROMOTION_KEY')) {
-    define('SVIC_PROMOTION_KEY', 'fathers_day');
+    define('SVIC_PROMOTION_KEY', 'july_4');
 }
 
 if (!defined('SVIC_PROMOTION_CODE')) {
-    define('SVIC_PROMOTION_CODE', 'DAD2026');
+    define('SVIC_PROMOTION_CODE', 'JULY4');
 }
 
 if (!defined('SVIC_PROMOTION_START')) {
-    define('SVIC_PROMOTION_START', '2026-06-19 00:00:00');
+    define('SVIC_PROMOTION_START', '2026-07-04 00:00:00');
 }
 
 if (!defined('SVIC_PROMOTION_END')) {
-    define('SVIC_PROMOTION_END', '2026-06-22 23:59:59');
+    define('SVIC_PROMOTION_END', '2026-07-04 23:59:59');
 }
 
 if (!defined('SVIC_PROMOTION_RATE')) {
@@ -42,11 +42,11 @@ if (!defined('SVIC_PROMOTION_PRODUCT_IDS')) {
 }
 
 if (!defined('SVIC_PROMOTION_DESCRIPTION')) {
-    define('SVIC_PROMOTION_DESCRIPTION', 'Father\'s Day 2026: 5% off all SVICLOUD products.');
+    define('SVIC_PROMOTION_DESCRIPTION', 'July 4th 2026: 5% off all SVICLOUD products.');
 }
 
 if (!defined('SVIC_PROMOTION_SYNC_MARK')) {
-    define('SVIC_PROMOTION_SYNC_MARK', '20260619-02');
+    define('SVIC_PROMOTION_SYNC_MARK', '20260704-01');
 }
 
 if (!function_exists('svic_active_promotion_config')) {

--- a/theme/svicloudtvbox-lumen/lang/en_US.php
+++ b/theme/svicloudtvbox-lumen/lang/en_US.php
@@ -12,17 +12,17 @@ return [
     ],
 
     'promotion' => [
-        'fathers_day' => [
-            'aria_label'          => 'Father\'s Day promotion',
-            'eyebrow'             => 'Father\'s Day Weekend',
-            'message'             => 'Celebrate Dad with a better way to stream.',
-            'offers_label'        => 'Father\'s Day eligible offer',
+        'july_4' => [
+            'aria_label'          => 'July 4th promotion',
+            'eyebrow'             => 'July 4th Holiday Sale',
+            'message'             => 'Celebrate with 5% off SVICLOUD products.',
+            'offers_label'        => 'July 4th eligible offer',
             'offer_10p'           => 'All SVICLOUD products save 5%',
             'offer_10s'           => 'All SVICLOUD products save 5%',
             'code_label'          => 'Code {{code}}',
             'cta'                 => 'Shop the offer',
-            'coupon_not_active'   => 'DAD2026 is valid from June 19 through June 22, 2026.',
-            'coupon_not_eligible' => 'DAD2026 applies to SVICLOUD products only.',
+            'coupon_not_active'   => 'JULY4 is valid on July 4, 2026.',
+            'coupon_not_eligible' => 'JULY4 applies to SVICLOUD products only.',
         ],
     ],
 

--- a/theme/svicloudtvbox-lumen/lang/zh_CN.php
+++ b/theme/svicloudtvbox-lumen/lang/zh_CN.php
@@ -13,17 +13,17 @@ $overrides = [
     ],
 
     'promotion' => [
-        'fathers_day' => [
-            'aria_label'          => '父亲节优惠',
-            'eyebrow'             => '父亲节周末',
-            'message'             => '用更好的流媒体体验庆祝父亲节。',
-            'offers_label'        => '父亲节适用优惠',
+        'july_4' => [
+            'aria_label'          => '美国国庆优惠',
+            'eyebrow'             => '7 月 4 日假期优惠',
+            'message'             => '庆祝假期，SVICLOUD 商品省 5%。',
+            'offers_label'        => '7 月 4 日适用优惠',
             'offer_10p'           => 'SVICLOUD 全线商品省 5%',
-            'offer_10s'           => '全店省 5%',
+            'offer_10s'           => 'SVICLOUD 全线商品省 5%',
             'code_label'          => '代码 {{code}}',
             'cta'                 => '选购优惠',
-            'coupon_not_active'   => 'DAD2026 适用日期为 2026 年 6 月 19 日至 6 月 22 日。',
-            'coupon_not_eligible' => 'DAD2026 适用于 SVICLOUD 商品。',
+            'coupon_not_active'   => 'JULY4 适用日期为 2026 年 7 月 4 日。',
+            'coupon_not_eligible' => 'JULY4 适用于 SVICLOUD 商品。',
         ],
     ],
 

--- a/theme/svicloudtvbox-lumen/lang/zh_TW.php
+++ b/theme/svicloudtvbox-lumen/lang/zh_TW.php
@@ -12,17 +12,17 @@ return [
     ],
 
     'promotion' => [
-        'fathers_day' => [
-            'aria_label'          => '父親節優惠',
-            'eyebrow'             => '父親節週末',
-            'message'             => '用更好的串流體驗慶祝父親節。',
-            'offers_label'        => '父親節適用優惠',
+        'july_4' => [
+            'aria_label'          => '美國國慶優惠',
+            'eyebrow'             => '7 月 4 日假期優惠',
+            'message'             => '慶祝假期，SVICLOUD 商品省 5%。',
+            'offers_label'        => '7 月 4 日適用優惠',
             'offer_10p'           => 'SVICLOUD 全線商品省 5%',
-            'offer_10s'           => '全店省 5%',
+            'offer_10s'           => 'SVICLOUD 全線商品省 5%',
             'code_label'          => '代碼 {{code}}',
             'cta'                 => '選購優惠',
-            'coupon_not_active'   => 'DAD2026 適用日期為 2026 年 6 月 19 日至 6 月 22 日。',
-            'coupon_not_eligible' => 'DAD2026 適用於 SVICLOUD 商品。',
+            'coupon_not_active'   => 'JULY4 適用日期為 2026 年 7 月 4 日。',
+            'coupon_not_eligible' => 'JULY4 適用於 SVICLOUD 商品。',
         ],
     ],
 


### PR DESCRIPTION
## Summary
- enable the active promotion flag for July 4 only
- create/sync WooCommerce coupon code JULY4 at 5% off eligible SVICLOUD products
- update English, Traditional Chinese, and Simplified Chinese promotion banner copy

## Verification
- php -l theme/svicloudtvbox-lumen/inc/active-promotion.php
- php -l theme/svicloudtvbox-lumen/lang/en_US.php
- php -l theme/svicloudtvbox-lumen/lang/zh_TW.php
- php -l theme/svicloudtvbox-lumen/lang/zh_CN.php
- reviewed promo visibility and coupon validation paths

## Deployment notes / rollback
- Deploy theme after merge.
- Rollback by reverting this PR or setting SVIC_PROMOTION_ENABLED false.