### PR TITLE
Add Chinese versions for SEO growth pages

### DIFF
--- a/docs/blog/best-chinese-tv-box-usa-2026.md
+++ b/docs/blog/best-chinese-tv-box-usa-2026.md
@@ -2,7 +2,7 @@
 slug: best-chinese-tv-box-usa-2026
 title: "Best Chinese TV Box for the USA in 2026"
 description: "Compare the best Chinese TV box options for U.S. families in 2026, including SVICLOUD, EVPAD, UBOX, SuperBox, warranty, setup, support, and buying risks."
-status: draft
+status: publish
 date: 2026-08-06T15:55:00-07:00
 category: Buying Checklist
 category_slug: buying-checklist

--- a/docs/blog/flushing-nyc-chinese-tv-box-guide.md
+++ b/docs/blog/flushing-nyc-chinese-tv-box-guide.md
@@ -2,7 +2,7 @@
 slug: flushing-nyc-chinese-tv-box-guide
 title: "Chinese TV Box in Flushing and NYC: SVICLOUD Buying Guide"
 description: "A Flushing, Queens, and New York City buying guide for Chinese TV box shoppers comparing SVICLOUD models, setup, shipping, warranty, and support."
-status: draft
+status: publish
 date: 2026-08-06T16:02:00-07:00
 category: Buying Checklist
 category_slug: buying-checklist

--- a/docs/blog/genuine-svicloud-box-usa-buying-guide.md
+++ b/docs/blog/genuine-svicloud-box-usa-buying-guide.md
@@ -2,7 +2,7 @@
 slug: genuine-svicloud-box-usa-buying-guide
 title: "How to Buy a Genuine SVICLOUD Box in the USA"
 description: "Learn how U.S. buyers can check SVICLOUD model details, warranty, shipping, seller support, and authenticity signals before ordering."
-status: draft
+status: publish
 date: 2026-08-06T15:59:00-07:00
 category: Buying Checklist
 category_slug: buying-checklist

--- a/docs/blog/los-angeles-chinese-tv-box-guide.md
+++ b/docs/blog/los-angeles-chinese-tv-box-guide.md
@@ -2,7 +2,7 @@
 slug: los-angeles-chinese-tv-box-guide
 title: "Chinese TV Box in Los Angeles: SVICLOUD Buying Guide"
 description: "A Los Angeles and San Gabriel Valley buying guide for Chinese TV box shoppers comparing SVICLOUD models, shipping, setup, warranty, and support."
-status: draft
+status: publish
 date: 2026-08-06T16:01:00-07:00
 category: Buying Checklist
 category_slug: buying-checklist

--- a/docs/blog/svicloud-vs-evpad-ubox-superbox-usa.md
+++ b/docs/blog/svicloud-vs-evpad-ubox-superbox-usa.md
@@ -2,7 +2,7 @@
 slug: svicloud-vs-evpad-ubox-superbox-usa
 title: "SVICLOUD vs EVPAD vs UBOX vs SuperBox: U.S. Buyer Comparison"
 description: "Compare SVICLOUD, EVPAD, UBOX, and SuperBox for U.S. buyers by setup, support, warranty, seller risk, and model fit."
-status: draft
+status: publish
 date: 2026-08-06T15:56:00-07:00
 category: Comparisons
 category_slug: comparisons

--- a/docs/blog/svicloud-warranty-usa-guide.md
+++ b/docs/blog/svicloud-warranty-usa-guide.md
@@ -2,7 +2,7 @@
 slug: svicloud-warranty-usa-guide
 title: "SVICLOUD Warranty in the USA: What Buyers Should Check"
 description: "Understand SVICLOUD warranty, returns, support, and troubleshooting steps for U.S. buyers before and after ordering."
-status: draft
+status: publish
 date: 2026-08-06T16:00:00-07:00
 category: Buying Checklist
 category_slug: buying-checklist

--- a/docs/blog/yogurt-tv-install-content-guide.md
+++ b/docs/blog/yogurt-tv-install-content-guide.md
@@ -2,7 +2,7 @@
 slug: yogurt-tv-install-content-guide
 title: "Yogurt TV on SVICLOUD: Install, Setup, and Content Sections Guide"
 description: "Learn how to approach Yogurt TV setup on SVICLOUD, including safe installation steps, language sections, updates, and support guidance."
-status: draft
+status: publish
 date: 2026-08-06T15:58:00-07:00
 category: Guides
 category_slug: guides

--- a/docs/blog/yogurt-tv-not-working-svicloud-guide.md
+++ b/docs/blog/yogurt-tv-not-working-svicloud-guide.md
@@ -2,7 +2,7 @@
 slug: yogurt-tv-not-working-svicloud-guide
 title: "Yogurt TV Not Working on SVICLOUD? Fixes to Try First"
 description: "Troubleshoot Yogurt TV on a SVICLOUD TV Box, including Wi-Fi, app loading, buffering, black screen, remote, and support steps."
-status: draft
+status: publish
 date: 2026-08-06T15:57:00-07:00
 category: Guides
 category_slug: guides

--- a/docs/blog/zh-cn/best-chinese-tv-box-usa-2026.md
+++ b/docs/blog/zh-cn/best-chinese-tv-box-usa-2026.md
@@ -1,0 +1,101 @@
+---
+slug: best-chinese-tv-box-usa-2026
+title: "2026 年美国最佳中文电视盒怎么选"
+description: "面向美国家庭的中文电视盒选购指南，比较 SVICLOUD、EVPAD、UBOX、SuperBox 的型号、保修、设置支持与购买风险。"
+status: publish
+date: 2026-08-06T15:55:00-07:00
+category: "Buying Checklist"
+category_slug: buying-checklist
+keywords:
+  - "美国中文电视盒推荐"
+  - "美国华人电视盒"
+  - "海外家庭中文电视盒"
+  - "SVICLOUD 美国"
+---
+
+# 2026 年美国最佳中文电视盒怎么选
+
+在美国给家人挑中文电视盒，不应该只看规格表或功能数量。更稳妥的选择，是适合家里使用者、发货来源清楚、保修与退货条款公开，而且收货后有人可以协助设置的产品。
+
+这篇指南整理真正会影响购买体验的因素：型号是否适合、设置难不难、保修是否清楚、客服是否找得到，以及向不明卖家购买的风险。
+
+## 快速建议
+
+如果你想要 SVICLOUD 目前较高阶的型号、更顺的多任务表现、较大的存储空间、语音遥控与更适合家庭客厅的硬件，选 **SVICLOUD 10P+**。
+
+如果你想要较简单、价格更好、适合日常家庭观看、第二台电视或不需要旗舰功能的使用者，选 **SVICLOUD 10S**。
+
+购买前先看官方比较页：[SVICLOUD 10P+ vs 10S](https://svicloudtvbox.us/compare/)。
+
+## 比规格更重要的事
+
+很多买家会先比较 RAM、存储空间和处理器名称。这些当然重要，但它们没有回答更关键的问题：
+
+- 父母或长辈是否容易操作？
+- 卖家是否清楚说明发货与退货？
+- 遥控器、Wi-Fi 或 App 出问题时是否有人协助？
+- 保修条款是否在结账前就看得到？
+- 商品页是否使用最新型号信息，而不是过期名称？
+
+对多数美国买家来说，支持与保修的重要性不低于硬件规格。
+
+## SVICLOUD 与其他中文电视盒品牌
+
+SVICLOUD、EVPAD、UBOX 和 SuperBox 都常出现在买家搜索中。正确比较方式取决于买家的实际需求：
+
+- 如果想要清楚的美国购买流程与官方支持，先比较 SVICLOUD 10P+ 和 10S。
+- 如果正在比较品牌，要看保修、设置、客服与卖家风险。
+- 如果是因为旧盒子 App 不稳才想换机，建议先排除网络、缓存与更新问题。
+
+延伸阅读：[SVICLOUD vs EVPAD vs UBOX vs SuperBox](https://svicloudtvbox.us/svicloud-vs-evpad-ubox-superbox-usa/)。
+
+## 给父母和长辈使用
+
+给父母使用时，最好的中文电视盒通常不是规格最高的那台，而是出问题时最容易恢复正常的那台。请优先确认：
+
+- 遥控器操作流程简单。
+- 有清楚的设置说明。
+- 有双语支持。
+- Wi-Fi 或有线网络稳定。
+- App、遥控器与保修问题有支持渠道。
+
+设置前可先看：[SVICLOUD 设置指南](https://svicloudtvbox.us/guides-setup/)。
+
+## 美国发货与保修
+
+购买任何电视盒前，请先确认：
+
+- 订单从哪里发货。
+- 退货期限是否公开。
+- 保修由卖家处理，还是被推给第三方。
+- 客服是否会要求订单号、型号、照片或截图来协助判断。
+
+SVICLOUD TV Box US 公开提供：
+
+- [Shipping policy](https://svicloudtvbox.us/shipping-policy/)
+- [Return policy](https://svicloudtvbox.us/return-policy/)
+- [Contact support](https://svicloudtvbox.us/contact/)
+
+## 多数买家的 SVICLOUD 型号选择
+
+主客厅使用、预算允许时，优先选 **SVICLOUD 10P+**，硬件余裕更高。
+
+卧室、客房、宿舍或预算较低的情境，可选 **SVICLOUD 10S**。
+
+比较与购买：
+
+- [Shop SVICLOUD 10P+](https://svicloudtvbox.us/product/svicloud-10p-plus/)
+- [Shop SVICLOUD 10S](https://svicloudtvbox.us/product/svicloud-10s/)
+- [Compare SVICLOUD models](https://svicloudtvbox.us/compare/)
+
+## 最后检查清单
+
+下单前确认：
+
+- 型号符合房间与使用者需求。
+- 发货与退货条款清楚。
+- 卖家有可联系的客服。
+- 你知道去哪里找设置与故障排除说明。
+- 购买来源可验证。
+
+不确定时，先联系客服再结账：[Contact SVICLOUD support](https://svicloudtvbox.us/contact/)。

--- a/docs/blog/zh-cn/flushing-nyc-chinese-tv-box-guide.md
+++ b/docs/blog/zh-cn/flushing-nyc-chinese-tv-box-guide.md
@@ -1,0 +1,70 @@
+---
+slug: flushing-nyc-chinese-tv-box-guide
+title: "法拉盛与纽约中文电视盒选购指南：SVICLOUD 型号与支持"
+description: "给法拉盛、皇后区与纽约市买家的中文电视盒指南，整理 SVICLOUD 型号、设置、发货、保修与客服。"
+status: publish
+date: 2026-08-06T16:02:00-07:00
+category: "Buying Checklist"
+category_slug: buying-checklist
+keywords:
+  - "法拉盛中文电视盒"
+  - "纽约中文电视盒"
+  - "皇后区中文电视盒"
+  - "SVICLOUD 纽约"
+---
+
+# 法拉盛与纽约中文电视盒选购指南
+
+对法拉盛、皇后区、布鲁克林与纽约市家庭来说，中文电视盒常是为家庭观看、父母或第二台电视购买。正确选择应该容易设置、容易支持，并清楚说明保修与退货。
+
+## 纽约买家应该确认什么
+
+购买前请确认：
+
+- 出售的确切型号。
+- 设置说明是否清楚。
+- 客服是否容易联系。
+- 发货、退货与保修条款是否公开。
+- 盒子是否适合使用者：主客厅、父母、公寓或客房。
+
+在纽约，很多购买是为父母、亲戚或小公寓准备，盒子需要简单可靠。较强型号有帮助，但支持路径同样重要。如果买家无法轻松取得 Wi-Fi、App 设置、遥控器配对或保修问题协助，最低价格可能变成最贵的选择。
+
+主客厅或每天使用的家庭，可选择性能余裕更高的型号。备用电视、客房或预算较低时，价值型号可能已足够。
+
+## SVICLOUD 10P+ 还是 10S？
+
+如果你想要主电视、较重 App 使用与更高性能余裕，选 **SVICLOUD 10P+**。
+
+如果你想要日常观看或第二台电视的高性价比型号，选 **SVICLOUD 10S**。
+
+使用型号比较页：
+
+[SVICLOUD 10P+ vs 10S](https://svicloudtvbox.us/compare/)
+
+## 设置与故障排除
+
+如果盒子要给父母或长辈使用，请保存这些页面：
+
+- [Setup guide](https://svicloudtvbox.us/guides-setup/)
+- [App guide](https://svicloudtvbox.us/guides-apps/)
+- [Troubleshooting guide](https://svicloudtvbox.us/guides-troubleshooting/)
+
+交给家人前先设置一次。确认 HDMI 输入、Wi-Fi、遥控器配对与基本 App 操作。如果出问题，知道型号、订单号与卡在哪一步，客服会更快协助。
+
+## 更有信心地购买
+
+下单前使用官方政策页：
+
+- [Shipping policy](https://svicloudtvbox.us/shipping-policy/)
+- [Return policy](https://svicloudtvbox.us/return-policy/)
+- [Contact support](https://svicloudtvbox.us/contact/)
+
+## 最佳下一步
+
+比较目前 SVICLOUD 型号：
+
+[Compare SVICLOUD models](https://svicloudtvbox.us/compare/)
+
+或在购买前联系客服：
+
+[Contact SVICLOUD TV Box US](https://svicloudtvbox.us/contact/)

--- a/docs/blog/zh-cn/genuine-svicloud-box-usa-buying-guide.md
+++ b/docs/blog/zh-cn/genuine-svicloud-box-usa-buying-guide.md
@@ -1,0 +1,79 @@
+---
+slug: genuine-svicloud-box-usa-buying-guide
+title: "在美国如何购买正品 SVICLOUD 盒子"
+description: "美国买家下单前应如何确认 SVICLOUD 型号、保修、发货、卖家支持与正品购买信号。"
+status: publish
+date: 2026-08-06T15:59:00-07:00
+category: "Buying Checklist"
+category_slug: buying-checklist
+keywords:
+  - "正品 SVICLOUD 美国"
+  - "SVICLOUD 授权经销商"
+  - "美国购买 SVICLOUD"
+  - "正品中文电视盒"
+---
+
+# 在美国如何购买正品 SVICLOUD 盒子
+
+当多个卖家使用相似产品名称时，美国买家下单前应该先放慢速度，把基本信息确认清楚。可靠的购买路径应该让型号、发货、保修、退货政策与客服联系方式都容易找到。
+
+## 检查型号名称
+
+SVICLOUD TV Box US 目前主要型号路径是：
+
+- [SVICLOUD 10P+](https://svicloudtvbox.us/product/svicloud-10p-plus/)
+- [SVICLOUD 10S](https://svicloudtvbox.us/product/svicloud-10s/)
+- [SVICLOUD model comparison](https://svicloudtvbox.us/compare/)
+
+请小心混用旧型号名称、规格不清或照片过期的商品页。
+
+如果商品页只写“最新款”或“旗舰款”，但没有清楚标示 10P+ 或 10S，建议先询问卖家再下单。清楚的型号名称能避免收到与预期不同的设备。
+
+## 检查政策页
+
+购买前请确认：
+
+- 商品从哪里发货。
+- 退货期限是什么。
+- 保修支持包含哪些内容。
+- 如何联系客服。
+
+这些信息如果分散、缺失或写得很模糊，代表之后遇到问题时也可能需要花更多时间沟通。对买给父母或长辈的订单来说，清楚政策比便宜几美元更重要。
+
+实用页面：
+
+- [Shipping policy](https://svicloudtvbox.us/shipping-policy/)
+- [Return policy](https://svicloudtvbox.us/return-policy/)
+- [Contact support](https://svicloudtvbox.us/contact/)
+
+## 结账前先确认支持
+
+如果是买给父母、长辈或不熟悉科技的家庭，客服支持很重要。可以先确认是否能协助：
+
+- 第一次设置。
+- Wi-Fi 或有线网络问题。
+- 遥控器配对。
+- App 安装问题。
+- 保修或退货问题。
+
+能在购买前清楚回答这些问题的卖家，通常也比较容易在收货后提供有效支持。
+
+## 留意风险信号
+
+如果卖家有以下情况，请特别小心：
+
+- 没有公开退货或保修条款。
+- 商品照片模糊或过于笼统。
+- 无法说清楚出售的型号。
+- 作出政策页没有写明的承诺。
+- 没有清楚的客服联系方式。
+
+## 最佳下一步
+
+如果你已经决定要 SVICLOUD，先比较型号：
+
+[Compare SVICLOUD 10P+ vs 10S](https://svicloudtvbox.us/compare/)
+
+如果还有任何不清楚，下单前先询问：
+
+[Contact SVICLOUD TV Box US](https://svicloudtvbox.us/contact/)

--- a/docs/blog/zh-cn/los-angeles-chinese-tv-box-guide.md
+++ b/docs/blog/zh-cn/los-angeles-chinese-tv-box-guide.md
@@ -1,0 +1,72 @@
+---
+slug: los-angeles-chinese-tv-box-guide
+title: "洛杉矶中文电视盒选购指南：SVICLOUD 型号、设置与支持"
+description: "给洛杉矶与圣盖博谷买家的中文电视盒指南，整理 SVICLOUD 型号、发货、设置、保修与客服重点。"
+status: publish
+date: 2026-08-06T16:01:00-07:00
+category: "Buying Checklist"
+category_slug: buying-checklist
+keywords:
+  - "洛杉矶中文电视盒"
+  - "圣盖博谷中文电视盒"
+  - "SVICLOUD 洛杉矶"
+  - "加州中文电视盒"
+---
+
+# 洛杉矶中文电视盒选购指南
+
+洛杉矶与圣盖博谷有许多中文家庭，会为父母、长辈、公寓、餐厅或客厅选购电视盒。最好的选择不是只看功能，而是设置容易、收货后也容易支持的产品。
+
+## 洛杉矶买家通常需要什么
+
+常见需求包括：
+
+- 家中中文娱乐需求。
+- 父母容易使用的遥控器流程。
+- 双语设置支持。
+- 快速美国发货。
+- 清楚的保修与退货条款。
+
+许多洛杉矶买家不是买给自己，而是买给住在 Monterey Park、Alhambra、Arcadia、Rowland Heights、Irvine 或南加州其他地区的父母家人。真正使用盒子的人，可能不想自己排除 App 或网络问题。这会改变选购重点：清楚的设置说明与售后支持，比单纯低价更重要。
+
+如果盒子要放在主客厅，请优先考虑性能与简单支持。如果是卧室或第二台电视，性价比可能更重要。
+
+## 哪个 SVICLOUD 型号适合？
+
+主客厅、较重度使用、需要语音遥控与较高性能时，选 **SVICLOUD 10P+**。
+
+卧室、公寓、日常观看或预算更敏感时，选 **SVICLOUD 10S**。
+
+比较两款型号：
+
+[SVICLOUD 10P+ vs 10S](https://svicloudtvbox.us/compare/)
+
+## 给家庭使用的设置协助
+
+如果盒子是给父母或长辈使用，设置比规格表更重要。
+
+实用指南：
+
+- [First-time setup](https://svicloudtvbox.us/guides-setup/)
+- [App installation](https://svicloudtvbox.us/guides-apps/)
+- [Troubleshooting](https://svicloudtvbox.us/guides-troubleshooting/)
+
+交给家人前，建议先接上一次，确认遥控器、Wi-Fi 和基本操作正常，并保存客服页面。这个小检查能避免之后很多“不能用”的电话。
+
+## 发货与支持
+
+下单前先看政策页：
+
+- [Shipping policy](https://svicloudtvbox.us/shipping-policy/)
+- [Return policy](https://svicloudtvbox.us/return-policy/)
+- [Contact support](https://svicloudtvbox.us/contact/)
+
+## 最佳下一步
+
+准备比较型号时，从这里开始：
+
+[Compare SVICLOUD models](https://svicloudtvbox.us/compare/)
+
+如果需要帮父母或家人挑型号：
+
+[Contact SVICLOUD TV Box US](https://svicloudtvbox.us/contact/)

--- a/docs/blog/zh-cn/svicloud-vs-evpad-ubox-superbox-usa.md
+++ b/docs/blog/zh-cn/svicloud-vs-evpad-ubox-superbox-usa.md
@@ -1,0 +1,95 @@
+---
+slug: svicloud-vs-evpad-ubox-superbox-usa
+title: "SVICLOUD vs EVPAD vs UBOX vs SuperBox：美国买家比较"
+description: "从设置、客服、保修、卖家风险与型号清楚度，帮美国买家比较 SVICLOUD、EVPAD、UBOX 和 SuperBox。"
+status: publish
+date: 2026-08-06T15:56:00-07:00
+category: "Comparisons"
+category_slug: comparisons
+keywords:
+  - "SVICLOUD vs EVPAD"
+  - "SVICLOUD vs UBOX"
+  - "SVICLOUD vs SuperBox"
+  - "美国中文电视盒比较"
+---
+
+# SVICLOUD vs EVPAD vs UBOX vs SuperBox
+
+美国买家比较 SVICLOUD、EVPAD、UBOX 和 SuperBox 时，真正的问题不只是“哪台功能更多？”更好的问题是：盒子送到家后，哪一条购买与支持路径最省麻烦？
+
+这篇比较聚焦实际购买因素：设置、客服、保修、型号清楚度与卖家风险。
+
+## 快速比较
+
+**SVICLOUD** 适合想要美国导向购买流程、清楚型号选择、双语设置协助与本地化支持的买家。
+
+**EVPAD** 常出现在中文电视盒品牌比较与旧款型号搜索中。
+
+**UBOX / Unblock Tech** 常被搜索全球电视盒的使用者拿来比较。
+
+**SuperBox** 常被美国买家视为 Android TV box 替代选项，购买体验通常偏英文。
+
+如果你主要在选 SVICLOUD 型号，先看官方页：[SVICLOUD 10P+ vs 10S](https://svicloudtvbox.us/compare/)。
+
+## 真正重要的比较因素
+
+### 1. 设置
+
+最适合科技熟手的盒子，不一定最适合父母。如果设备要给父母、长辈或不熟悉科技的家人使用，设置支持很重要。
+
+实用链接：
+
+- [SVICLOUD setup guide](https://svicloudtvbox.us/guides-setup/)
+- [SVICLOUD app guide](https://svicloudtvbox.us/guides-apps/)
+
+### 2. 故障排除
+
+任何电视盒都可能遇到 Wi-Fi、遥控器、App、缓冲或画面问题。好的购买路径应该让故障排除更容易。
+
+从这里开始：[SVICLOUD troubleshooting guide](https://svicloudtvbox.us/guides-troubleshooting/)。
+
+### 3. 保修与退货
+
+不要只看功能清单就下单。请确认卖家是否公开：
+
+- 退货期限。
+- 保修范围。
+- 客服联系方式。
+- 发货时间。
+
+SVICLOUD TV Box US 政策页：
+
+- [Shipping policy](https://svicloudtvbox.us/shipping-policy/)
+- [Return policy](https://svicloudtvbox.us/return-policy/)
+- [Contact support](https://svicloudtvbox.us/contact/)
+
+### 4. 型号清楚度
+
+许多品牌网上有旧型号名称流传，容易让购买变混乱。SVICLOUD 在美国主要选择是：
+
+- [SVICLOUD 10P+](https://svicloudtvbox.us/product/svicloud-10p-plus/)：较高阶性能。
+- [SVICLOUD 10S](https://svicloudtvbox.us/product/svicloud-10s/)：日常使用与高性价比。
+
+## 谁适合选 SVICLOUD？
+
+如果买家重视以下项目，SVICLOUD 会是合适选择：
+
+- 面向美国买家的产品指引。
+- 双语支持。
+- 清楚的 10P+ vs 10S 选择。
+- 公开的发货、退货与保修信息。
+- 收货后仍有设置与故障排除协助。
+
+## 谁应该多比较几个品牌？
+
+如果你已经拥有 EVPAD、UBOX 或 SuperBox，正在考虑是否更换，或想比较旧盒子的替代方案，可以多比较几个品牌。重点不只看功能，也要看卖家支持与保修差异。
+
+## 最佳下一步
+
+如果你已经决定要看 SVICLOUD，先比较型号：
+
+[Compare SVICLOUD 10P+ and 10S](https://svicloudtvbox.us/compare/)
+
+购买前需要协助：
+
+[Contact SVICLOUD TV Box US](https://svicloudtvbox.us/contact/)

--- a/docs/blog/zh-cn/svicloud-warranty-usa-guide.md
+++ b/docs/blog/zh-cn/svicloud-warranty-usa-guide.md
@@ -1,0 +1,82 @@
+---
+slug: svicloud-warranty-usa-guide
+title: "美国 SVICLOUD 保修：买家下单前该确认什么"
+description: "了解美国买家在购买 SVICLOUD 前后应确认的保修、退货、客服与故障排除步骤。"
+status: publish
+date: 2026-08-06T16:00:00-07:00
+category: "Buying Checklist"
+category_slug: buying-checklist
+keywords:
+  - "SVICLOUD 美国保修"
+  - "SVICLOUD 退货政策"
+  - "SVICLOUD 美国客服"
+  - "中文电视盒保修"
+---
+
+# 美国 SVICLOUD 保修：买家下单前该确认什么
+
+保修问题通常会在两个时间点出现：购买前，以及设置遇到问题后。本指南帮助美国买家了解下单前该确认什么，以及需要客服时应准备哪些资料。
+
+## 购买前
+
+先查看官方页面：
+
+- [Shipping policy](https://svicloudtvbox.us/shipping-policy/)
+- [Return policy](https://svicloudtvbox.us/return-policy/)
+- [Contact support](https://svicloudtvbox.us/contact/)
+
+政策页是最可靠的依据。不要只依赖截图、旧论坛文章或第三方说法。
+
+如果看到不同网站或社群留言提供互相矛盾的保修说法，请以你实际购买网站上的政策页与客服回复为准。
+
+## 下单后要保存什么
+
+请保留：
+
+- 订单号。
+- Email 收据。
+- 产品型号。
+- 发货追踪。
+- 包装与配件照片。
+
+如果之后需要协助，这些资料能让客服更快判断。
+
+收到商品后，也建议先确认配件是否齐全，包含电源、HDMI 线、遥控器与其他随盒配件。若包装或配件异常，越早拍照回报越好处理。
+
+## 申请保修前先排除问题
+
+许多问题与设置有关，不一定是硬件故障。提出保修请求前，先确认：
+
+- Wi-Fi 或有线网络连接。
+- HDMI 输入与线材。
+- 遥控器电池与配对。
+- App 缓存或更新。
+- 重新启动电源。
+
+如果问题只出现在单一 App，通常先从 App 缓存、更新与网络连接开始排查。如果整台盒子无法开机、持续重启或多个 App 同时失败，再把状况整理给客服会更有效率。
+
+支持入口：
+
+[SVICLOUD troubleshooting guide](https://svicloudtvbox.us/guides-troubleshooting/)
+
+## 何时联系客服
+
+如果出现以下情况，请联系客服：
+
+- 盒子无法开机。
+- 重新启动后仍卡住。
+- 网络排除后多个 App 仍失败。
+- 收到错误商品。
+- 包裹抵达时已损坏。
+
+请提供订单号、型号、照片或截图，以及已尝试的步骤。
+
+[Contact SVICLOUD support](https://svicloudtvbox.us/contact/)
+
+## 更有信心地选型号
+
+如果还在决定买哪一台：
+
+- [SVICLOUD 10P+](https://svicloudtvbox.us/product/svicloud-10p-plus/) 是性能更强的选择。
+- [SVICLOUD 10S](https://svicloudtvbox.us/product/svicloud-10s/) 是日常使用的高性价比选择。
+- 结账前先 [Compare both models](https://svicloudtvbox.us/compare/)。

--- a/docs/blog/zh-cn/yogurt-tv-install-content-guide.md
+++ b/docs/blog/zh-cn/yogurt-tv-install-content-guide.md
@@ -1,0 +1,72 @@
+---
+slug: yogurt-tv-install-content-guide
+title: "SVICLOUD 上的 Yogurt TV：安装、设置与内容分类指南"
+description: "了解在 SVICLOUD 上设置 Yogurt TV 的安全方式，包括安装步骤、语言分类、更新与客服协助。"
+status: publish
+date: 2026-08-06T15:58:00-07:00
+category: "Guides"
+category_slug: guides
+keywords:
+  - "Yogurt TV 安装教程"
+  - "Yogurt TV SVICLOUD"
+  - "Yogurt TV 中文 韩文 日文 美国"
+  - "SVICLOUD App 教程"
+---
+
+# SVICLOUD 上的 Yogurt TV：安装、设置与内容分类指南
+
+Yogurt TV 是许多 SVICLOUD 用户在设置中文、韩文、日文与美国娱乐分类时会询问的 App。第三方 App 的可用性与菜单可能随时间改变，因此本页是设置与支持指南，不是任何第三方内容的保证。
+
+## 先看 App 指南
+
+App 安装与更新步骤，请使用官方 SVICLOUD 指南：
+
+[SVICLOUD app installation guide](https://svicloudtvbox.us/guides-apps/)
+
+这能避免不安全的 APK 来源，也让客服在协助时有共同基准。
+
+## 安装前要确认什么
+
+安装或更新 Yogurt TV 前，请确认：
+
+- 盒子已连接稳定 Wi-Fi 或有线网络。
+- 系统日期与时间正确。
+- 重大 App 变更后重新启动盒子。
+- 避免从不明来源安装重复版本。
+- 如需客服协助，先准备好订单号。
+
+## 用户常问的内容分类
+
+SVICLOUD 客服常收到关于 Yogurt TV 这类 App 内中文、韩文、日文与 USA 分类的问题。菜单与可用性可能改变，安装后请以 App 内实际显示为准。
+
+如果某个分类消失或无法加载，请先排除 App 问题，不要立刻判定是硬件故障。
+
+给父母或长辈使用时，建议先由家人完成一次基本设置：确认 Wi-Fi、遥控器、常用菜单与返回键都能正常操作。这样之后如果需要客服协助，也能更清楚描述卡在哪一步。
+
+## 如果 Yogurt TV 打不开
+
+请看专门的故障排除指南：
+
+[Yogurt TV not working on SVICLOUD](https://svicloudtvbox.us/yogurt-tv-not-working-svicloud-guide/)
+
+常见处理方式包括重新启动盒子、检查网络、清除 App 缓存，以及确认安装路径。
+
+## 什么时候联系客服
+
+如果你需要以下协助，请联系客服：
+
+- 第一次设置 App。
+- App 加载问题。
+- 遥控器操作。
+- Wi-Fi 或有线网络调整。
+- 选择 SVICLOUD 10P+ 或 10S。
+
+[Contact SVICLOUD support](https://svicloudtvbox.us/contact/)
+
+## 为 App 使用购买新盒子
+
+如果主要是为家庭娱乐与 App 支持购买，请比较目前 SVICLOUD 型号：
+
+- [SVICLOUD 10P+](https://svicloudtvbox.us/product/svicloud-10p-plus/)
+- [SVICLOUD 10S](https://svicloudtvbox.us/product/svicloud-10s/)
+- [Compare 10P+ vs 10S](https://svicloudtvbox.us/compare/)

--- a/docs/blog/zh-cn/yogurt-tv-not-working-svicloud-guide.md
+++ b/docs/blog/zh-cn/yogurt-tv-not-working-svicloud-guide.md
@@ -1,0 +1,77 @@
+---
+slug: yogurt-tv-not-working-svicloud-guide
+title: "Yogurt TV 在 SVICLOUD 上不能用？先试这些排除步骤"
+description: "排除 SVICLOUD 电视盒上 Yogurt TV 无法打开、缓冲、黑屏、遥控器或网络相关问题，并了解何时联系客服。"
+status: publish
+date: 2026-08-06T15:57:00-07:00
+category: "Guides"
+category_slug: guides
+keywords:
+  - "Yogurt TV 不能用"
+  - "Yogurt TV SVICLOUD"
+  - "SVICLOUD App 不能用"
+  - "中文电视盒 App 故障排除"
+---
+
+# Yogurt TV 在 SVICLOUD 上不能用？先试这些排除步骤
+
+如果 Yogurt TV 无法打开、一直缓冲、出现黑屏，或在 SVICLOUD TV Box 上无法正常加载，先不要认定盒子坏了。多数 App 问题来自网络、缓存、更新或设置流程。
+
+更换设备前，先照这份清单检查。
+
+## 1. 重新启动盒子和路由器
+
+关闭 SVICLOUD 盒子，拔掉电源一分钟，再重新启动路由器。等 Wi-Fi 完全恢复后，重新接上盒子测试。
+
+如果盒子离路由器太远，请尝试有线网络，或把盒子移近 Wi-Fi 来源。
+
+## 2. 确认网络真的可用
+
+Wi-Fi 显示“已连接”不代表影音 App 一定能正常联网。请测试其他 App 或浏览器页面。如果多个 App 都失败，问题很可能与网络有关。
+
+更完整的 Wi-Fi 排除方式：
+
+[SVICLOUD troubleshooting guide](https://svicloudtvbox.us/guides-troubleshooting/)
+
+## 3. 清除 App 缓存
+
+打开 Android 设置，找到 App 清单，选择 Yogurt TV，然后清除缓存。重新打开 App 再测试。
+
+除非客服要求，避免直接清除 App 数据，因为可能移除已保存的设置。
+
+## 4. 检查安装步骤
+
+如果 App 最近刚安装或更新，请确认安装流程是否正确。可参考官方 App 指南：
+
+[SVICLOUD app installation guide](https://svicloudtvbox.us/guides-apps/)
+
+## 5. 检查遥控器与输入源
+
+有时 App 正常，但遥控器没有反应，或电视切到错误 HDMI 输入。可以尝试：
+
+- 更换遥控器电池。
+- 重新配对蓝牙遥控器。
+- 确认电视切到正确 HDMI 输入。
+- 配对后重新启动盒子。
+
+## 6. 什么时候该联系客服
+
+如果出现以下情况，请联系客服：
+
+- 重新启动与清除缓存后，Yogurt TV 仍无法打开。
+- 盒子卡在 Logo 或恢复画面。
+- 多个 App 都出现同样问题。
+- 重复看到相同错误信息。
+- 最近更换了网络服务或路由器设备。
+
+请附上订单号、设备型号、App 名称、照片或截图，以及已经尝试过的步骤。
+
+[Contact SVICLOUD support](https://svicloudtvbox.us/contact/)
+
+## 需要升级盒子吗？
+
+先排除问题，再考虑升级。如果旧盒子仍然很慢、经常卡住，或无法负荷你常用的 App，再比较目前型号：
+
+- [SVICLOUD 10P+](https://svicloudtvbox.us/product/svicloud-10p-plus/)
+- [SVICLOUD 10S](https://svicloudtvbox.us/product/svicloud-10s/)
+- [Compare 10P+ vs 10S](https://svicloudtvbox.us/compare/)

--- a/docs/blog/zh/best-chinese-tv-box-usa-2026.md
+++ b/docs/blog/zh/best-chinese-tv-box-usa-2026.md
@@ -1,0 +1,101 @@
+---
+slug: best-chinese-tv-box-usa-2026
+title: "2026 年美國最佳中文電視盒怎麼選"
+description: "面向美國家庭的中文電視盒選購指南，比較 SVICLOUD、EVPAD、UBOX、SuperBox 的型號、保固、設定支援與購買風險。"
+status: publish
+date: 2026-08-06T15:55:00-07:00
+category: "Buying Checklist"
+category_slug: buying-checklist
+keywords:
+  - "美國中文電視盒推薦"
+  - "美國華人電視盒"
+  - "海外家庭中文電視盒"
+  - "SVICLOUD 美國"
+---
+
+# 2026 年美國最佳中文電視盒怎麼選
+
+在美國幫家人挑中文電視盒，不應該只看規格表或功能數量。更穩妥的選擇，是適合家中使用者、出貨來源清楚、保固與退貨條款公開，而且收貨後有人可以協助設定的產品。
+
+這篇指南整理真正會影響購買體驗的因素：型號是否適合、設定難不難、保固是否清楚、客服是否找得到，以及向不明賣家購買的風險。
+
+## 快速建議
+
+如果你想要 SVICLOUD 目前較高階的型號、更順的多工表現、較大的儲存空間、語音遙控與更適合家庭客廳的硬體，選 **SVICLOUD 10P+**。
+
+如果你想要較簡單、價格更好、適合日常家庭觀看、第二台電視或不需要旗艦功能的使用者，選 **SVICLOUD 10S**。
+
+購買前先看官方比較頁：[SVICLOUD 10P+ vs 10S](https://svicloudtvbox.us/compare/)。
+
+## 比規格更重要的事
+
+很多買家會先比較 RAM、儲存空間和處理器名稱。這些當然重要，但它們沒有回答更關鍵的問題：
+
+- 父母或長輩是否容易操作？
+- 賣家是否清楚說明出貨與退貨？
+- 遙控器、Wi-Fi 或 App 出問題時是否有人協助？
+- 保固條款是否在結帳前就看得到？
+- 商品頁是否使用最新型號資訊，而不是過期名稱？
+
+對多數美國買家來說，支援與保固的重要性不低於硬體規格。
+
+## SVICLOUD 與其他中文電視盒品牌
+
+SVICLOUD、EVPAD、UBOX 和 SuperBox 都常出現在買家搜尋中。正確比較方式取決於買家的實際需求：
+
+- 如果想要清楚的美國購買流程與官方支援，先比較 SVICLOUD 10P+ 和 10S。
+- 如果正在比較品牌，要看保固、設定、客服與賣家風險。
+- 如果是因為舊盒子 App 不穩才想換機，建議先排除網路、快取與更新問題。
+
+延伸閱讀：[SVICLOUD vs EVPAD vs UBOX vs SuperBox](https://svicloudtvbox.us/svicloud-vs-evpad-ubox-superbox-usa/)。
+
+## 給父母和長輩使用
+
+給父母使用時，最好的中文電視盒通常不是規格最高的那台，而是出問題時最容易恢復正常的那台。請優先確認：
+
+- 遙控器操作流程簡單。
+- 有清楚的設定說明。
+- 有雙語支援。
+- Wi-Fi 或有線網路穩定。
+- App、遙控器與保固問題有支援管道。
+
+設定前可先看：[SVICLOUD 設定指南](https://svicloudtvbox.us/guides-setup/)。
+
+## 美國出貨與保固
+
+購買任何電視盒前，請先確認：
+
+- 訂單從哪裡出貨。
+- 退貨期限是否公開。
+- 保固由賣家處理，還是被推給第三方。
+- 客服是否會要求訂單號、型號、照片或截圖來協助判斷。
+
+SVICLOUD TV Box US 公開提供：
+
+- [Shipping policy](https://svicloudtvbox.us/shipping-policy/)
+- [Return policy](https://svicloudtvbox.us/return-policy/)
+- [Contact support](https://svicloudtvbox.us/contact/)
+
+## 多數買家的 SVICLOUD 型號選擇
+
+主客廳使用、預算允許時，優先選 **SVICLOUD 10P+**，硬體餘裕更高。
+
+臥室、客房、宿舍或預算較低的情境，可選 **SVICLOUD 10S**。
+
+比較與購買：
+
+- [Shop SVICLOUD 10P+](https://svicloudtvbox.us/product/svicloud-10p-plus/)
+- [Shop SVICLOUD 10S](https://svicloudtvbox.us/product/svicloud-10s/)
+- [Compare SVICLOUD models](https://svicloudtvbox.us/compare/)
+
+## 最後檢查清單
+
+下單前確認：
+
+- 型號符合房間與使用者需求。
+- 出貨與退貨條款清楚。
+- 賣家有可聯繫的客服。
+- 你知道去哪裡找設定與故障排除說明。
+- 購買來源可驗證。
+
+不確定時，先聯絡客服再結帳：[Contact SVICLOUD support](https://svicloudtvbox.us/contact/)。

--- a/docs/blog/zh/flushing-nyc-chinese-tv-box-guide.md
+++ b/docs/blog/zh/flushing-nyc-chinese-tv-box-guide.md
@@ -1,0 +1,70 @@
+---
+slug: flushing-nyc-chinese-tv-box-guide
+title: "法拉盛與紐約中文電視盒選購指南：SVICLOUD 型號與支援"
+description: "給法拉盛、皇后區與紐約市買家的中文電視盒指南，整理 SVICLOUD 型號、設定、出貨、保固與客服。"
+status: publish
+date: 2026-08-06T16:02:00-07:00
+category: "Buying Checklist"
+category_slug: buying-checklist
+keywords:
+  - "法拉盛中文電視盒"
+  - "紐約中文電視盒"
+  - "皇后區中文電視盒"
+  - "SVICLOUD 紐約"
+---
+
+# 法拉盛與紐約中文電視盒選購指南
+
+對法拉盛、皇后區、布魯克林與紐約市家庭來說，中文電視盒常是為家庭觀看、父母或第二台電視購買。正確選擇應該容易設定、容易支援，並清楚說明保固與退貨。
+
+## 紐約買家應該確認什麼
+
+購買前請確認：
+
+- 販售的確切型號。
+- 設定說明是否清楚。
+- 客服是否容易聯絡。
+- 出貨、退貨與保固條款是否公開。
+- 盒子是否適合使用者：主客廳、父母、公寓或客房。
+
+在紐約，很多購買是為父母、親戚或小公寓準備，盒子需要簡單可靠。較強型號有幫助，但支援路徑同樣重要。如果買家無法輕鬆取得 Wi-Fi、App 設定、遙控器配對或保固問題協助，最低價格可能變成最貴的選擇。
+
+主客廳或每天使用的家庭，可選擇效能餘裕更高的型號。備用電視、客房或預算較低時，價值型號可能已足夠。
+
+## SVICLOUD 10P+ 還是 10S？
+
+如果你想要主電視、較重 App 使用與更高效能餘裕，選 **SVICLOUD 10P+**。
+
+如果你想要日常觀看或第二台電視的高性價比型號，選 **SVICLOUD 10S**。
+
+使用型號比較頁：
+
+[SVICLOUD 10P+ vs 10S](https://svicloudtvbox.us/compare/)
+
+## 設定與故障排除
+
+如果盒子要給父母或長輩使用，請保存這些頁面：
+
+- [Setup guide](https://svicloudtvbox.us/guides-setup/)
+- [App guide](https://svicloudtvbox.us/guides-apps/)
+- [Troubleshooting guide](https://svicloudtvbox.us/guides-troubleshooting/)
+
+交給家人前先設定一次。確認 HDMI 輸入、Wi-Fi、遙控器配對與基本 App 操作。如果出問題，知道型號、訂單號與卡在哪一步，客服會更快協助。
+
+## 更有信心地購買
+
+下單前使用官方政策頁：
+
+- [Shipping policy](https://svicloudtvbox.us/shipping-policy/)
+- [Return policy](https://svicloudtvbox.us/return-policy/)
+- [Contact support](https://svicloudtvbox.us/contact/)
+
+## 最佳下一步
+
+比較目前 SVICLOUD 型號：
+
+[Compare SVICLOUD models](https://svicloudtvbox.us/compare/)
+
+或在購買前聯絡客服：
+
+[Contact SVICLOUD TV Box US](https://svicloudtvbox.us/contact/)

--- a/docs/blog/zh/genuine-svicloud-box-usa-buying-guide.md
+++ b/docs/blog/zh/genuine-svicloud-box-usa-buying-guide.md
@@ -1,0 +1,79 @@
+---
+slug: genuine-svicloud-box-usa-buying-guide
+title: "在美國如何購買正品 SVICLOUD 盒子"
+description: "美國買家下單前應如何確認 SVICLOUD 型號、保固、出貨、賣家支援與正品購買訊號。"
+status: publish
+date: 2026-08-06T15:59:00-07:00
+category: "Buying Checklist"
+category_slug: buying-checklist
+keywords:
+  - "正品 SVICLOUD 美國"
+  - "SVICLOUD 授權經銷商"
+  - "美國購買 SVICLOUD"
+  - "正品中文電視盒"
+---
+
+# 在美國如何購買正品 SVICLOUD 盒子
+
+當多個賣家使用相似產品名稱時，美國買家下單前應該先放慢速度，把基本資訊確認清楚。可靠的購買路徑應該讓型號、出貨、保固、退貨政策與客服聯絡方式都容易找到。
+
+## 檢查型號名稱
+
+SVICLOUD TV Box US 目前主要型號路徑是：
+
+- [SVICLOUD 10P+](https://svicloudtvbox.us/product/svicloud-10p-plus/)
+- [SVICLOUD 10S](https://svicloudtvbox.us/product/svicloud-10s/)
+- [SVICLOUD model comparison](https://svicloudtvbox.us/compare/)
+
+請小心混用舊型號名稱、規格不清或照片過期的商品頁。
+
+如果商品頁只寫「最新款」或「旗艦款」，但沒有清楚標示 10P+ 或 10S，建議先詢問賣家再下單。清楚的型號名稱能避免收到與預期不同的設備。
+
+## 檢查政策頁
+
+購買前請確認：
+
+- 商品從哪裡出貨。
+- 退貨期限是什麼。
+- 保固支援包含哪些內容。
+- 如何聯絡客服。
+
+這些資訊如果分散、缺失或寫得很模糊，代表之後遇到問題時也可能需要花更多時間溝通。對買給父母或長輩的訂單來說，清楚政策比便宜幾美元更重要。
+
+實用頁面：
+
+- [Shipping policy](https://svicloudtvbox.us/shipping-policy/)
+- [Return policy](https://svicloudtvbox.us/return-policy/)
+- [Contact support](https://svicloudtvbox.us/contact/)
+
+## 結帳前先確認支援
+
+如果是買給父母、長輩或不熟悉科技的家庭，客服支援很重要。可以先確認是否能協助：
+
+- 第一次設定。
+- Wi-Fi 或有線網路問題。
+- 遙控器配對。
+- App 安裝問題。
+- 保固或退貨問題。
+
+能在購買前清楚回答這些問題的賣家，通常也比較容易在收貨後提供有效支援。
+
+## 留意風險訊號
+
+如果賣家有以下情況，請特別小心：
+
+- 沒有公開退貨或保固條款。
+- 商品照片模糊或過於籠統。
+- 無法說清楚販售的型號。
+- 作出政策頁沒有寫明的承諾。
+- 沒有清楚的客服聯絡方式。
+
+## 最佳下一步
+
+如果你已經決定要 SVICLOUD，先比較型號：
+
+[Compare SVICLOUD 10P+ vs 10S](https://svicloudtvbox.us/compare/)
+
+如果還有任何不清楚，下單前先詢問：
+
+[Contact SVICLOUD TV Box US](https://svicloudtvbox.us/contact/)

--- a/docs/blog/zh/los-angeles-chinese-tv-box-guide.md
+++ b/docs/blog/zh/los-angeles-chinese-tv-box-guide.md
@@ -1,0 +1,72 @@
+---
+slug: los-angeles-chinese-tv-box-guide
+title: "洛杉磯中文電視盒選購指南：SVICLOUD 型號、設定與支援"
+description: "給洛杉磯與聖蓋博谷買家的中文電視盒指南，整理 SVICLOUD 型號、出貨、設定、保固與客服重點。"
+status: publish
+date: 2026-08-06T16:01:00-07:00
+category: "Buying Checklist"
+category_slug: buying-checklist
+keywords:
+  - "洛杉磯中文電視盒"
+  - "聖蓋博谷中文電視盒"
+  - "SVICLOUD 洛杉磯"
+  - "加州中文電視盒"
+---
+
+# 洛杉磯中文電視盒選購指南
+
+洛杉磯與聖蓋博谷有許多中文家庭，會為父母、長輩、公寓、餐廳或客廳選購電視盒。最好的選擇不是只看功能，而是設定容易、收貨後也容易支援的產品。
+
+## 洛杉磯買家通常需要什麼
+
+常見需求包括：
+
+- 家中中文娛樂需求。
+- 父母容易使用的遙控器流程。
+- 雙語設定支援。
+- 快速美國出貨。
+- 清楚的保固與退貨條款。
+
+許多洛杉磯買家不是買給自己，而是買給住在 Monterey Park、Alhambra、Arcadia、Rowland Heights、Irvine 或南加州其他地區的父母家人。真正使用盒子的人，可能不想自己排除 App 或網路問題。這會改變選購重點：清楚的設定說明與售後支援，比單純低價更重要。
+
+如果盒子要放在主客廳，請優先考慮效能與簡單支援。如果是臥室或第二台電視，性價比可能更重要。
+
+## 哪個 SVICLOUD 型號適合？
+
+主客廳、較重度使用、需要語音遙控與較高效能時，選 **SVICLOUD 10P+**。
+
+臥室、公寓、日常觀看或預算更敏感時，選 **SVICLOUD 10S**。
+
+比較兩款型號：
+
+[SVICLOUD 10P+ vs 10S](https://svicloudtvbox.us/compare/)
+
+## 給家庭使用的設定協助
+
+如果盒子是給父母或長輩使用，設定比規格表更重要。
+
+實用指南：
+
+- [First-time setup](https://svicloudtvbox.us/guides-setup/)
+- [App installation](https://svicloudtvbox.us/guides-apps/)
+- [Troubleshooting](https://svicloudtvbox.us/guides-troubleshooting/)
+
+交給家人前，建議先接上一次，確認遙控器、Wi-Fi 和基本操作正常，並保存客服頁面。這個小檢查能避免之後很多「不能用」的電話。
+
+## 出貨與支援
+
+下單前先看政策頁：
+
+- [Shipping policy](https://svicloudtvbox.us/shipping-policy/)
+- [Return policy](https://svicloudtvbox.us/return-policy/)
+- [Contact support](https://svicloudtvbox.us/contact/)
+
+## 最佳下一步
+
+準備比較型號時，從這裡開始：
+
+[Compare SVICLOUD models](https://svicloudtvbox.us/compare/)
+
+如果需要幫父母或家人挑型號：
+
+[Contact SVICLOUD TV Box US](https://svicloudtvbox.us/contact/)

--- a/docs/blog/zh/svicloud-vs-evpad-ubox-superbox-usa.md
+++ b/docs/blog/zh/svicloud-vs-evpad-ubox-superbox-usa.md
@@ -1,0 +1,95 @@
+---
+slug: svicloud-vs-evpad-ubox-superbox-usa
+title: "SVICLOUD vs EVPAD vs UBOX vs SuperBox：美國買家比較"
+description: "從設定、客服、保固、賣家風險與型號清楚度，幫美國買家比較 SVICLOUD、EVPAD、UBOX 和 SuperBox。"
+status: publish
+date: 2026-08-06T15:56:00-07:00
+category: "Comparisons"
+category_slug: comparisons
+keywords:
+  - "SVICLOUD vs EVPAD"
+  - "SVICLOUD vs UBOX"
+  - "SVICLOUD vs SuperBox"
+  - "美國中文電視盒比較"
+---
+
+# SVICLOUD vs EVPAD vs UBOX vs SuperBox
+
+美國買家比較 SVICLOUD、EVPAD、UBOX 和 SuperBox 時，真正的問題不只是「哪台功能更多？」更好的問題是：盒子送到家後，哪一條購買與支援路徑最省麻煩？
+
+這篇比較聚焦實際購買因素：設定、客服、保固、型號清楚度與賣家風險。
+
+## 快速比較
+
+**SVICLOUD** 適合想要美國導向購買流程、清楚型號選擇、雙語設定協助與本地化支援的買家。
+
+**EVPAD** 常出現在中文電視盒品牌比較與舊款型號搜尋中。
+
+**UBOX / Unblock Tech** 常被搜尋全球電視盒的使用者拿來比較。
+
+**SuperBox** 常被美國買家視為 Android TV box 替代選項，購買體驗通常偏英文。
+
+如果你主要在選 SVICLOUD 型號，先看官方頁：[SVICLOUD 10P+ vs 10S](https://svicloudtvbox.us/compare/)。
+
+## 真正重要的比較因素
+
+### 1. 設定
+
+最適合科技熟手的盒子，不一定最適合父母。如果設備要給父母、長輩或不熟悉科技的家人使用，設定支援很重要。
+
+實用連結：
+
+- [SVICLOUD setup guide](https://svicloudtvbox.us/guides-setup/)
+- [SVICLOUD app guide](https://svicloudtvbox.us/guides-apps/)
+
+### 2. 故障排除
+
+任何電視盒都可能遇到 Wi-Fi、遙控器、App、緩衝或畫面問題。好的購買路徑應該讓故障排除更容易。
+
+從這裡開始：[SVICLOUD troubleshooting guide](https://svicloudtvbox.us/guides-troubleshooting/)。
+
+### 3. 保固與退貨
+
+不要只看功能清單就下單。請確認賣家是否公開：
+
+- 退貨期限。
+- 保固範圍。
+- 客服聯絡方式。
+- 出貨時間。
+
+SVICLOUD TV Box US 政策頁：
+
+- [Shipping policy](https://svicloudtvbox.us/shipping-policy/)
+- [Return policy](https://svicloudtvbox.us/return-policy/)
+- [Contact support](https://svicloudtvbox.us/contact/)
+
+### 4. 型號清楚度
+
+許多品牌網路上有舊型號名稱流傳，容易讓購買變混亂。SVICLOUD 在美國主要選擇是：
+
+- [SVICLOUD 10P+](https://svicloudtvbox.us/product/svicloud-10p-plus/)：較高階效能。
+- [SVICLOUD 10S](https://svicloudtvbox.us/product/svicloud-10s/)：日常使用與高性價比。
+
+## 誰適合選 SVICLOUD？
+
+如果買家重視以下項目，SVICLOUD 會是合適選擇：
+
+- 面向美國買家的產品指引。
+- 雙語支援。
+- 清楚的 10P+ vs 10S 選擇。
+- 公開的出貨、退貨與保固資訊。
+- 收貨後仍有設定與故障排除協助。
+
+## 誰應該多比較幾個品牌？
+
+如果你已經擁有 EVPAD、UBOX 或 SuperBox，正在考慮是否更換，或想比較舊盒子的替代方案，可以多比較幾個品牌。重點不只看功能，也要看賣家支援與保固差異。
+
+## 最佳下一步
+
+如果你已經決定要看 SVICLOUD，先比較型號：
+
+[Compare SVICLOUD 10P+ and 10S](https://svicloudtvbox.us/compare/)
+
+購買前需要協助：
+
+[Contact SVICLOUD TV Box US](https://svicloudtvbox.us/contact/)

--- a/docs/blog/zh/svicloud-warranty-usa-guide.md
+++ b/docs/blog/zh/svicloud-warranty-usa-guide.md
@@ -1,0 +1,82 @@
+---
+slug: svicloud-warranty-usa-guide
+title: "美國 SVICLOUD 保固：買家下單前該確認什麼"
+description: "了解美國買家在購買 SVICLOUD 前後應確認的保固、退貨、客服與故障排除步驟。"
+status: publish
+date: 2026-08-06T16:00:00-07:00
+category: "Buying Checklist"
+category_slug: buying-checklist
+keywords:
+  - "SVICLOUD 美國保固"
+  - "SVICLOUD 退貨政策"
+  - "SVICLOUD 美國客服"
+  - "中文電視盒保固"
+---
+
+# 美國 SVICLOUD 保固：買家下單前該確認什麼
+
+保固問題通常會在兩個時間點出現：購買前，以及設定遇到問題後。本指南幫助美國買家了解下單前該確認什麼，以及需要客服時應準備哪些資料。
+
+## 購買前
+
+先查看官方頁面：
+
+- [Shipping policy](https://svicloudtvbox.us/shipping-policy/)
+- [Return policy](https://svicloudtvbox.us/return-policy/)
+- [Contact support](https://svicloudtvbox.us/contact/)
+
+政策頁是最可靠的依據。不要只依賴截圖、舊論壇文章或第三方說法。
+
+如果看到不同網站或社群留言提供互相矛盾的保固說法，請以你實際購買網站上的政策頁與客服回覆為準。
+
+## 下單後要保存什麼
+
+請保留：
+
+- 訂單號。
+- Email 收據。
+- 產品型號。
+- 出貨追蹤。
+- 包裝與配件照片。
+
+如果之後需要協助，這些資料能讓客服更快判斷。
+
+收到商品後，也建議先確認配件是否齊全，包含電源、HDMI 線、遙控器與其他隨盒配件。若包裝或配件異常，越早拍照回報越好處理。
+
+## 申請保固前先排除問題
+
+許多問題與設定有關，不一定是硬體故障。提出保固請求前，先確認：
+
+- Wi-Fi 或有線網路連線。
+- HDMI 輸入與線材。
+- 遙控器電池與配對。
+- App 快取或更新。
+- 重新啟動電源。
+
+如果問題只出現在單一 App，通常先從 App 快取、更新與網路連線開始排查。如果整台盒子無法開機、持續重啟或多個 App 同時失敗，再把狀況整理給客服會更有效率。
+
+支援入口：
+
+[SVICLOUD troubleshooting guide](https://svicloudtvbox.us/guides-troubleshooting/)
+
+## 何時聯絡客服
+
+如果出現以下情況，請聯絡客服：
+
+- 盒子無法開機。
+- 重新啟動後仍卡住。
+- 網路排除後多個 App 仍失敗。
+- 收到錯誤商品。
+- 包裹抵達時已損壞。
+
+請提供訂單號、型號、照片或截圖，以及已嘗試的步驟。
+
+[Contact SVICLOUD support](https://svicloudtvbox.us/contact/)
+
+## 更有信心地選型號
+
+如果還在決定買哪一台：
+
+- [SVICLOUD 10P+](https://svicloudtvbox.us/product/svicloud-10p-plus/) 是效能更強的選擇。
+- [SVICLOUD 10S](https://svicloudtvbox.us/product/svicloud-10s/) 是日常使用的高性價比選擇。
+- 結帳前先 [Compare both models](https://svicloudtvbox.us/compare/)。

--- a/docs/blog/zh/yogurt-tv-install-content-guide.md
+++ b/docs/blog/zh/yogurt-tv-install-content-guide.md
@@ -1,0 +1,72 @@
+---
+slug: yogurt-tv-install-content-guide
+title: "SVICLOUD 上的 Yogurt TV：安裝、設定與內容分類指南"
+description: "了解在 SVICLOUD 上設定 Yogurt TV 的安全方式，包括安裝步驟、語言分類、更新與客服協助。"
+status: publish
+date: 2026-08-06T15:58:00-07:00
+category: "Guides"
+category_slug: guides
+keywords:
+  - "Yogurt TV 安裝教學"
+  - "Yogurt TV SVICLOUD"
+  - "Yogurt TV 中文 韓文 日文 美國"
+  - "SVICLOUD App 教學"
+---
+
+# SVICLOUD 上的 Yogurt TV：安裝、設定與內容分類指南
+
+Yogurt TV 是許多 SVICLOUD 使用者在設定中文、韓文、日文與美國娛樂分類時會詢問的 App。第三方 App 的可用性與選單可能隨時間改變，因此本頁是設定與支援指南，不是任何第三方內容的保證。
+
+## 先看 App 指南
+
+App 安裝與更新步驟，請使用官方 SVICLOUD 指南：
+
+[SVICLOUD app installation guide](https://svicloudtvbox.us/guides-apps/)
+
+這能避免不安全的 APK 來源，也讓客服在協助時有共同基準。
+
+## 安裝前要確認什麼
+
+安裝或更新 Yogurt TV 前，請確認：
+
+- 盒子已連接穩定 Wi-Fi 或有線網路。
+- 系統日期與時間正確。
+- 重大 App 變更後重新啟動盒子。
+- 避免從不明來源安裝重複版本。
+- 如需客服協助，先準備好訂單號。
+
+## 使用者常問的內容分類
+
+SVICLOUD 客服常收到關於 Yogurt TV 這類 App 內中文、韓文、日文與 USA 分類的問題。選單與可用性可能改變，安裝後請以 App 內實際顯示為準。
+
+如果某個分類消失或無法載入，請先排除 App 問題，不要立刻判定是硬體故障。
+
+給父母或長輩使用時，建議先由家人完成一次基本設定：確認 Wi-Fi、遙控器、常用選單與返回鍵都能正常操作。這樣之後如果需要客服協助，也能更清楚描述卡在哪一步。
+
+## 如果 Yogurt TV 打不開
+
+請看專門的故障排除指南：
+
+[Yogurt TV not working on SVICLOUD](https://svicloudtvbox.us/yogurt-tv-not-working-svicloud-guide/)
+
+常見處理方式包括重新啟動盒子、檢查網路、清除 App 快取，以及確認安裝路徑。
+
+## 什麼時候聯絡客服
+
+如果你需要以下協助，請聯絡客服：
+
+- 第一次設定 App。
+- App 載入問題。
+- 遙控器操作。
+- Wi-Fi 或有線網路調整。
+- 選擇 SVICLOUD 10P+ 或 10S。
+
+[Contact SVICLOUD support](https://svicloudtvbox.us/contact/)
+
+## 為 App 使用購買新盒子
+
+如果主要是為家庭娛樂與 App 支援購買，請比較目前 SVICLOUD 型號：
+
+- [SVICLOUD 10P+](https://svicloudtvbox.us/product/svicloud-10p-plus/)
+- [SVICLOUD 10S](https://svicloudtvbox.us/product/svicloud-10s/)
+- [Compare 10P+ vs 10S](https://svicloudtvbox.us/compare/)

--- a/docs/blog/zh/yogurt-tv-not-working-svicloud-guide.md
+++ b/docs/blog/zh/yogurt-tv-not-working-svicloud-guide.md
@@ -1,0 +1,77 @@
+---
+slug: yogurt-tv-not-working-svicloud-guide
+title: "Yogurt TV 在 SVICLOUD 上不能用？先試這些排除步驟"
+description: "排除 SVICLOUD 電視盒上 Yogurt TV 無法開啟、緩衝、黑畫面、遙控器或網路相關問題，並了解何時聯絡客服。"
+status: publish
+date: 2026-08-06T15:57:00-07:00
+category: "Guides"
+category_slug: guides
+keywords:
+  - "Yogurt TV 不能用"
+  - "Yogurt TV SVICLOUD"
+  - "SVICLOUD App 不能用"
+  - "中文電視盒 App 故障排除"
+---
+
+# Yogurt TV 在 SVICLOUD 上不能用？先試這些排除步驟
+
+如果 Yogurt TV 無法開啟、一直緩衝、出現黑畫面，或在 SVICLOUD TV Box 上無法正常載入，先不要認定盒子壞了。多數 App 問題來自網路、快取、更新或設定流程。
+
+更換設備前，先照這份清單檢查。
+
+## 1. 重新啟動盒子和路由器
+
+關閉 SVICLOUD 盒子，拔掉電源一分鐘，再重新啟動路由器。等 Wi-Fi 完全恢復後，重新接上盒子測試。
+
+如果盒子離路由器太遠，請嘗試有線網路，或把盒子移近 Wi-Fi 來源。
+
+## 2. 確認網路真的可用
+
+Wi-Fi 顯示「已連線」不代表影音 App 一定能正常連網。請測試其他 App 或瀏覽器頁面。如果多個 App 都失敗，問題很可能與網路有關。
+
+更完整的 Wi-Fi 排除方式：
+
+[SVICLOUD troubleshooting guide](https://svicloudtvbox.us/guides-troubleshooting/)
+
+## 3. 清除 App 快取
+
+打開 Android 設定，找到 App 清單，選擇 Yogurt TV，然後清除快取。重新開啟 App 再測試。
+
+除非客服要求，避免直接清除 App 資料，因為可能移除已儲存的設定。
+
+## 4. 檢查安裝步驟
+
+如果 App 最近剛安裝或更新，請確認安裝流程是否正確。可參考官方 App 指南：
+
+[SVICLOUD app installation guide](https://svicloudtvbox.us/guides-apps/)
+
+## 5. 檢查遙控器與輸入源
+
+有時 App 正常，但遙控器沒有反應，或電視切到錯誤 HDMI 輸入。可以嘗試：
+
+- 更換遙控器電池。
+- 重新配對藍牙遙控器。
+- 確認電視切到正確 HDMI 輸入。
+- 配對後重新啟動盒子。
+
+## 6. 什麼時候該聯絡客服
+
+如果出現以下情況，請聯絡客服：
+
+- 重新啟動與清除快取後，Yogurt TV 仍無法開啟。
+- 盒子卡在 Logo 或恢復畫面。
+- 多個 App 都出現同樣問題。
+- 重複看到相同錯誤訊息。
+- 最近更換了網路服務或路由器設備。
+
+請附上訂單號、設備型號、App 名稱、照片或截圖，以及已經嘗試過的步驟。
+
+[Contact SVICLOUD support](https://svicloudtvbox.us/contact/)
+
+## 需要升級盒子嗎？
+
+先排除問題，再考慮升級。如果舊盒子仍然很慢、經常卡住，或無法負荷你常用的 App，再比較目前型號：
+
+- [SVICLOUD 10P+](https://svicloudtvbox.us/product/svicloud-10p-plus/)
+- [SVICLOUD 10S](https://svicloudtvbox.us/product/svicloud-10s/)
+- [Compare 10P+ vs 10S](https://svicloudtvbox.us/compare/)


### PR DESCRIPTION
## Summary
- Add zh-TW and zh-CN Markdown versions for the 8 new SEO growth pages
- Mark the English source pages as published to match WordPress state
- Update live WordPress posts with Traditional and Simplified Chinese title, description, keywords, and content meta

## Verification
- Localized Markdown validation passed for 24 files
- WordPress REST meta check confirmed zh-TW and zh-CN content exists for all 8 posts
- Playwright verified all /zh/... and /zh-cn/... live routes return 200 with localized H1s and no console errors